### PR TITLE
ci: publish docker image

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -11,7 +11,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: tag
-    if: false  # Change to true or remove line to publish to docker
     steps:
       - uses: actions/checkout@v3
       - name: Pull latest changes


### PR DESCRIPTION
Closes #29 

- When a pr is merged into main, a docker image will be built and published