### PR TITLE
fix: adds pip flag to allow finding index.html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ADD src ./src
 ADD pyproject.toml .
 ADD setup.py .
 
-# Pip command
-RUN pip install .[server] --no-cache-dir
+# Pip command. Without '-e' flag, index.html isn't found. There's probably a
+# better way to add the static html files to the site-packages.
+RUN pip install -e .[server] --no-cache-dir
 
 CMD ["uvicorn", "aind_data_transfer_service.server:app", "--host", "0.0.0.0", "--port", "5000"]


### PR DESCRIPTION
Hot fix to get the fast api service to be able to find the index.html file