### PR TITLE
Fix 84: Update modality validators in xlsx job template

### DIFF
--- a/src/aind_data_transfer_service/configs/job_upload_template.py
+++ b/src/aind_data_transfer_service/configs/job_upload_template.py
@@ -15,6 +15,7 @@ class JobUploadTemplate:
     """Class to configure and create xlsx job upload template"""
 
     FILE_NAME = "job_upload_template.xlsx"
+    NUM_TEMPLATE_ROWS = 20
     HEADERS = [
         "platform",
         "acq_datetime",
@@ -55,12 +56,15 @@ class JobUploadTemplate:
         {
             "name": "platform",
             "options": [p().abbreviation for p in Platform._ALL],
-            "ranges": ["A2:A20"],
+            "column_indexes": [HEADERS.index("platform")],
         },
         {
             "name": "modality",
             "options": [m().abbreviation for m in Modality._ALL],
-            "ranges": ["D2:D20", "F2:F20"],
+            "column_indexes": [
+                HEADERS.index("modality0"),
+                HEADERS.index("modality1"),
+            ],
         },
     ]
 
@@ -86,8 +90,9 @@ class JobUploadTemplate:
             dv.promptTitle = validator["name"]
             dv.prompt = f'Select a {validator["name"]} from the dropdown'
             dv.error = f'Invalid {validator["name"]}.'
-            for r in validator["ranges"]:
-                dv.add(r)
+            for i in validator["column_indexes"]:
+                col = get_column_letter(i + 1)
+                dv.add(f"{col}2:{col}{JobUploadTemplate.NUM_TEMPLATE_ROWS}")
             worksheet.add_data_validation(dv)
         # formatting
         bold = Font(bold=True)

--- a/tests/test_job_upload_template.py
+++ b/tests/test_job_upload_template.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 
 from openpyxl import load_workbook
+from openpyxl.utils import range_boundaries
 
 from aind_data_transfer_service.configs.job_upload_template import (
     JobUploadTemplate,
@@ -49,6 +50,15 @@ class TestJobUploadTemplate(unittest.TestCase):
             JobUploadTemplate.create_job_template(), True
         )
         self.assertEqual(expected_lines, template_lines)
+        for validator in template_validators:
+            validator["column_indexes"] = []
+            for r in validator["ranges"]:
+                rb = (col, *_) = range_boundaries(r)
+                self.assertTupleEqual(
+                    (col, 2, col, JobUploadTemplate.NUM_TEMPLATE_ROWS), rb
+                )
+                validator["column_indexes"].append(col - 1)
+            del validator["ranges"]
         self.assertCountEqual(
             JobUploadTemplate.VALIDATORS, template_validators
         )


### PR DESCRIPTION
closes #84 
- Needed to update validator ranges for modality cols in xlsx job template, due to removed s3_bucket column
- Updated hardcoded validator ranges to be generated based on the header column idx in xlsx job template