### PR TITLE
feat: add filters in jobs status page

### DIFF
--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -39,12 +39,13 @@ class AirflowDagRunsRequestParameters(BaseModel):
     offset: int = 0
     state: Optional[list[str]] = []
     order_by: str = "-start_date"
+    execution_date_gte: Optional[str] = None
 
     @classmethod
     def from_query_params(cls, query_params: dict):
         """Maps the query parameters to the model"""
         params = dict(query_params)
-        if 'state' in params and isinstance(params['state'], str):
+        if 'state' in params:
             params['state'] = ast.literal_eval(params['state'])
         return cls(**params)
 

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -39,15 +39,20 @@ class AirflowDagRunsRequestParameters(BaseModel):
     limit: int = 25
     offset: int = 0
     state: Optional[list[str]] = []
-    execution_date_gte: Optional[str] = (datetime.now(timezone.utc) - timedelta(weeks=2)).isoformat()
+    execution_date_gte: Optional[str] = (
+        datetime.now(timezone.utc) - timedelta(weeks=2)
+    ).isoformat()
     execution_date_lte: Optional[str] = None
     order_by: str = "-execution_date"
 
     @field_validator("execution_date_gte", mode="after")
     def validate_min_execution_date(cls, execution_date_gte: str):
         """Validate the earliest submit date filter is within 2 weeks"""
-        if datetime.fromisoformat(execution_date_gte) < datetime.now(timezone.utc) - timedelta(weeks=2):
-            raise ValueError("execution_date_gte must be within the last 2 weeks")
+        min_execution_date = datetime.now(timezone.utc) - timedelta(weeks=2)
+        if datetime.fromisoformat(execution_date_gte) < min_execution_date:
+            raise ValueError(
+                "execution_date_gte must be within the last 2 weeks"
+            )
         return execution_date_gte
 
     @classmethod

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -1,4 +1,5 @@
 """Module for data models used in application"""
+
 import ast
 from datetime import datetime
 from typing import List, Optional
@@ -38,7 +39,7 @@ class AirflowDagRunsRequestParameters(BaseModel):
     limit: int = 25
     offset: int = 0
     state: Optional[list[str]] = []
-    order_by: str = "-start_date"
+    order_by: str = "-execution_date"
     execution_date_gte: Optional[str] = None
 
     @classmethod

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -39,15 +39,16 @@ class AirflowDagRunsRequestParameters(BaseModel):
     limit: int = 25
     offset: int = 0
     state: Optional[list[str]] = []
-    order_by: str = "-execution_date"
     execution_date_gte: Optional[str] = None
+    execution_date_lte: Optional[str] = None 
+    order_by: str = "-execution_date"
 
     @classmethod
     def from_query_params(cls, query_params: dict):
         """Maps the query parameters to the model"""
         params = dict(query_params)
-        if 'state' in params:
-            params['state'] = ast.literal_eval(params['state'])
+        if "state" in params:
+            params["state"] = ast.literal_eval(params["state"])
         return cls(**params)
 
 

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -49,7 +49,9 @@ class AirflowDagRunsRequestParameters(BaseModel):
     def validate_min_execution_date(cls, execution_date_gte: str):
         """Validate the earliest submit date filter is within 2 weeks"""
         min_execution_date = datetime.now(timezone.utc) - timedelta(weeks=2)
-        if datetime.fromisoformat(execution_date_gte) < min_execution_date:
+        # datetime.fromisoformat does not support Z in python < 3.11
+        date_to_check = execution_date_gte.replace("Z", "+00:00")
+        if datetime.fromisoformat(date_to_check) < min_execution_date:
             raise ValueError(
                 "execution_date_gte must be within the last 2 weeks"
             )

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -1,5 +1,5 @@
 """Module for data models used in application"""
-
+import ast
 from datetime import datetime
 from typing import List, Optional
 
@@ -37,12 +37,16 @@ class AirflowDagRunsRequestParameters(BaseModel):
 
     limit: int = 25
     offset: int = 0
+    state: Optional[list[str]] = []
     order_by: str = "-start_date"
 
     @classmethod
     def from_query_params(cls, query_params: dict):
         """Maps the query parameters to the model"""
-        return cls(**query_params)
+        params = dict(query_params)
+        if 'state' in params and isinstance(params['state'], str):
+            params['state'] = ast.literal_eval(params['state'])
+        return cls(**params)
 
 
 class JobStatus(BaseModel):

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -486,6 +486,9 @@ async def jobs(request: Request):
     default_offset = AirflowDagRunsRequestParameters.model_fields[
         "offset"
     ].default
+    default_state = AirflowDagRunsRequestParameters.model_fields[
+        "state"
+    ].default
     return templates.TemplateResponse(
         name="job_status.html",
         context=(
@@ -493,6 +496,7 @@ async def jobs(request: Request):
                 "request": request,
                 "default_limit": default_limit,
                 "default_offset": default_offset,
+                "default_state": default_state,
                 "project_names_url": os.getenv(
                     "AIND_METADATA_SERVICE_PROJECT_NAMES_URL"
                 ),

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -391,12 +391,14 @@ async def get_job_status_list(request: Request):
     """Get status of jobs with default pagination of limit=25 and offset=0."""
     # TODO: Use httpx async client
     try:
+        url = os.getenv("AIND_AIRFLOW_SERVICE_JOBS_URL").strip("/")
         get_one_job = request.query_params.get("dag_run_id") is not None
         if get_one_job:
             dag_run_id = request.query_params["dag_run_id"]
-            params_dict = {"dag_run_id": dag_run_id} # only for returning to client
+            # params_dict is only for returning to client
+            params_dict = {"dag_run_id": dag_run_id}
             response_jobs = requests.get(
-                url=f'{os.getenv("AIND_AIRFLOW_SERVICE_JOBS_URL")}/{dag_run_id}',
+                url=f"{url}/{dag_run_id}",
                 auth=(
                     os.getenv("AIND_AIRFLOW_SERVICE_USER"),
                     os.getenv("AIND_AIRFLOW_SERVICE_PASSWORD"),
@@ -408,7 +410,7 @@ async def get_job_status_list(request: Request):
             )
             params_dict = json.loads(params.model_dump_json())
             response_jobs = requests.get(
-                url=os.getenv("AIND_AIRFLOW_SERVICE_JOBS_URL"),
+                url=url,
                 auth=(
                     os.getenv("AIND_AIRFLOW_SERVICE_USER"),
                     os.getenv("AIND_AIRFLOW_SERVICE_PASSWORD"),

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.8.1/font/bootstrap-icons.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>
@@ -43,6 +44,7 @@
         <div class="card mb-4" style="width:380px">
             <div class="card-header py-1">Filter by</div>
             <div class="card-body p-2">
+                <!-- filter by job status -->
                 <div class="input-group input-group-sm mb-1">
                     <span class="input-group-text" style="width:35%">Status</span>
                     <select class="form-select" onchange="filterJobsByStatus(this.value);this.blur();">
@@ -59,10 +61,29 @@
                         {% endfor %}
                     </select>
                 </div>
+                <!-- filter by job submitted date range -->
                 <div class="input-group input-group-sm">
                     <span class="input-group-text" style="width:35%">Submit Time</span>
                     <input id="submit-date-range" class="form-select" type="text" />
                 </div>
+                <!-- search by job id (exact match only) -->
+                <div class="d-flex align-items-center">
+                    <hr class="flex-grow-1 border-secondary">
+                    <span class="mx-2"><small class="d-block">or</small></span>
+                    <hr class="flex-grow-1 border-secondary">
+                </div>
+                <form onsubmit="searchByJobId(event)">
+                    <div class="input-group input-group-sm">
+                        <span class="input-group-text" style="width:35%">Job ID</span>
+                        <input id="job-id-input" type="text" class="form-control" placeholder="exact match only">
+                        <button class="btn btn-outline-secondary" type="submit" title="Search">
+                            <i class="bi bi-search"></i>
+                        </button>
+                        <button class="btn btn-outline-secondary" type="button" onclick="clearJobIdResult(event)" title="Clear">
+                            <i class="bi bi-x-lg"></i>
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
         <!-- toolbar to change jobs per page and navigate pages -->
@@ -130,17 +151,23 @@
                 execution_date_gte: twoWeeksAgo.startOf('day').toISOString(),
                 execution_date_lte: today.endOf('day').toISOString(),
             };
-            updateJobStatusTable(initialParams, true);
+            updateJobStatusTable(initialParams, false, true);
         });
         // EVENT HANDLERS ------------------------------------------------
-        function updateJobStatusTable(newParams, isInitial=false) {
+        function updateJobStatusTable(newParams, isSearchJobId=false, isInitial=false) {
             var iframe = document.getElementById('jobs-iframe');
             var currentUrl = isInitial ?  new URL("{{ url_for('job_status_table') }}") : new URL(iframe.src);
             Object.entries(newParams).forEach(([key, value]) => {
                 currentUrl.searchParams.set(key, value);
             });
+            // reset job_id filter
+            if (!isSearchJobId) {
+                document.getElementById('job-id-input').value = '';
+                currentUrl.searchParams.delete('dag_run_id');
+            }
             iframe.src = currentUrl.toString();
         }
+        // Filters
         function filterJobsByStatus(newStatus) {
             updateJobStatusTable({
                 state: newStatus,
@@ -155,6 +182,19 @@
                 offset: 0 // reset to first page
             });
         }
+        function searchByJobId(event) {
+            event.preventDefault();
+            // search by job id and reset to first page
+            const jobId = document.getElementById('job-id-input').value;
+            console.log('Searching for job ID:', jobId);
+            updateJobStatusTable({ dag_run_id: jobId, offset: 0}, true);
+        }
+        function clearJobIdResult(event) {
+            event.preventDefault();
+            // clear job id filter and reset to first page
+            updateJobStatusTable({ offset: 0 }, false);
+        }
+        // Pagination
         function updateJobStatusTableLimit(newLimit) {
             updateJobStatusTable({limit: newLimit});
         }

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -63,6 +63,23 @@
                 </select>
                 <span class="input-group-text">status</span>
             </div>
+            <div class="input-group">
+                <select class="form-select" onchange="updateJobStatusTableSubmitTimeWindow(this.value);this.blur();">
+                    {% for t in [
+                        {"label": "all", "value": "all"},
+                        {"label": "last 6 hours", "value": "6h"},
+                        {"label": "last 1 day", "value": "1d"},
+                        {"label": "last 3 days", "value": "3d"},
+                        {"label": "last 7 days", "value": "7d"},
+                        {"label": "last 14 days", "value": "14d" },
+                    ] %}
+                    {% if t.value=="all" %}<option value="{{ t.value }}" selected>{{ t.label }}</option>
+                    {% else %}<option value="{{ t.value }}">{{ t.label }}</option>
+                    {% endif %}
+                    {% endfor %}
+                </select>
+                <span class="input-group-text">submit time</span>
+            </div>
             <div class="btn-group" role="group">
                 <!-- display current jobs range e.g, "1 to 10 of 100" -->
                 <span id="jobs-iframe-showing" class="btn" style="cursor:default;"></span>
@@ -83,6 +100,7 @@
         <iframe id="jobs-iframe" src="{{ url_for('job_status_table').include_query_params(limit=default_limit, offset=default_offset,state=default_state)}}"></iframe>
     </div>
     <script>
+        const SUBMIT_TIME_WINDOW_REGEX = /(\d+)([hd])/;
         const PaginateTo = {
             NEXT: 'next',
             PREV: 'prev',
@@ -93,6 +111,25 @@
             var iframe = document.getElementById('jobs-iframe');
             var currentUrl = new URL(iframe.src);
             currentUrl.searchParams.set('state', newState);
+            iframe.src = currentUrl.toString();
+        }
+        function updateJobStatusTableSubmitTimeWindow(newWindow) {
+            var iframe = document.getElementById('jobs-iframe');
+            var currentUrl = new URL(iframe.src);
+            if (newWindow === "all") {
+                currentUrl.searchParams.delete('execution_date_gte');
+                console.log("currentUrl", currentUrl.toString());
+            } else {
+                // set new execution_date_gte for jobs submitted within the time window (e.g., 6h, 3d)
+                const match = newWindow.match(SUBMIT_TIME_WINDOW_REGEX);
+                if (!match) {
+                    console.error("Invalid time window format. Expected format: <number><h|d> (e.g., 6h, 1d, 3d, 7d, 14d)");
+                    return;
+                }
+                const [_, amount, unit] = match;
+                const execution_date_gte = moment().subtract(parseInt(amount), unit).toISOString();
+                currentUrl.searchParams.set('execution_date_gte', execution_date_gte);
+            }
             iframe.src = currentUrl.toString();
         }
         function updateJobStatusTableLimit(newLimit) {

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -109,6 +109,7 @@
             $('#submit-date-range').daterangepicker({
                 startDate: twoWeeksAgo,
                 endDate: today,
+                minDate: twoWeeksAgo,
                 maxDate: today,
                 ranges: {
                     'Today': [today, today],

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -16,7 +16,7 @@
         }
         .content {
             width: 100%;
-            height: calc(100vh - 200px);
+            height: calc(100vh - 300px);
             iframe {
                 border: none;
                 width: 100%;
@@ -35,28 +35,28 @@
     </nav>
     <div class="content">
         <!-- display total entries from child iframe -->
-        <h2 class="mb-3">Jobs Submitted: <span id="jobs-iframe-total-entries"></h2>
+        <h2 class="mb-2">Jobs Submitted: <span id="jobs-iframe-total-entries"></h2>
         <!-- filters for job status results-->
-        <div class="card">
-            <div class="card-header">Filter by</div>
-            <div class="card-body">
-                <div class="input-group">
-                    <span class="input-group-text">status</span>
+        <div class="card mb-4" style="width:350px">
+            <div class="card-header py-1">Filter by</div>
+            <div class="card-body p-2">
+                <div class="input-group input-group-sm mb-1">
+                    <span class="input-group-text" style="width:40%">status</span>
                     <select class="form-select" onchange="updateJobStatusTableState(this.value);this.blur();">
                         {% for s in [
                             {"label": "all", "value": []},
-                            {"label": "running", "value": ['running']},
-                            {"label": "failed", "value": ['failed']},
-                            {"label": "success", "value": ['success']},
+                            {"label": "running", "value": ['running'], "class": "text-info"},
+                            {"label": "failed", "value": ['failed'], "class": "text-danger"},
+                            {"label": "success", "value": ['success'], "class": "text-success"},
                         ] %}
-                        {% if s.value==default_state %}<option value="{{ s.value }}" selected>{{ s.label }}</option>
-                        {% else %}<option value="{{ s.value }}">{{ s.label }}</option>
+                        {% if s.value==default_state %}<option class="{{ s.class }}" value="{{ s.value }}" selected>{{ s.label }}</option>
+                        {% else %}<option class="{{ s.class }}" value="{{ s.value }}">{{ s.label }}</option>
                         {% endif %}
                         {% endfor %}
                     </select>
                 </div>
-                <div class="input-group">
-                    <span class="input-group-text">submit time</span>
+                <div class="input-group input-group-sm">
+                    <span class="input-group-text" style="width:40%">submit time</span>
                     <select class="form-select" onchange="updateJobStatusTableSubmitTimeWindow(this.value);this.blur();">
                         {% for t in [
                             {"label": "all", "value": "all"},

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -48,6 +48,21 @@
                 </select>
                 <span class="input-group-text">jobs per page</span>
             </div>
+            <div class="input-group">
+                <select class="form-select" onchange="updateJobStatusTableState(this.value);this.blur();">
+                    {% for s in [
+                        {"label": "all", "value": []},
+                        {"label": "running", "value": ['running']},
+                        {"label": "failed", "value": ['failed']},
+                        {"label": "success", "value": ['success']},
+                    ] %}
+                    {% if s.value==default_state %}<option value="{{ s.value }}" selected>{{ s.label }}</option>
+                    {% else %}<option value="{{ s.value }}">{{ s.label }}</option>
+                    {% endif %}
+                    {% endfor %}
+                </select>
+                <span class="input-group-text">status</span>
+            </div>
             <div class="btn-group" role="group">
                 <!-- display current jobs range e.g, "1 to 10 of 100" -->
                 <span id="jobs-iframe-showing" class="btn" style="cursor:default;"></span>
@@ -65,7 +80,7 @@
             </div>
         </div>
         <!-- iframe to display paginated job status table -->
-        <iframe id="jobs-iframe" src="{{ url_for('job_status_table').include_query_params(limit=default_limit, offset=default_offset)}}"></iframe>
+        <iframe id="jobs-iframe" src="{{ url_for('job_status_table').include_query_params(limit=default_limit, offset=default_offset,state=default_state)}}"></iframe>
     </div>
     <script>
         const PaginateTo = {
@@ -74,6 +89,12 @@
             FIRST: 'first',
             LAST: 'last'
         };
+        function updateJobStatusTableState(newState) {
+            var iframe = document.getElementById('jobs-iframe');
+            var currentUrl = new URL(iframe.src);
+            currentUrl.searchParams.set('state', newState);
+            iframe.src = currentUrl.toString();
+        }
         function updateJobStatusTableLimit(newLimit) {
             var iframe = document.getElementById('jobs-iframe');
             var currentUrl = new URL(iframe.src);

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -5,6 +5,9 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
     <title>{% block title %} {% endblock %} AIND Data Transfer Service Jobs</title>
     <style>
         body {
@@ -37,11 +40,11 @@
         <!-- display total entries from child iframe -->
         <h2 class="mb-2">Jobs Submitted: <span id="jobs-iframe-total-entries"></h2>
         <!-- filters for job status results-->
-        <div class="card mb-4" style="width:350px">
+        <div class="card mb-4" style="width:380px">
             <div class="card-header py-1">Filter by</div>
             <div class="card-body p-2">
                 <div class="input-group input-group-sm mb-1">
-                    <span class="input-group-text" style="width:40%">status</span>
+                    <span class="input-group-text" style="width:35%">Status</span>
                     <select class="form-select" onchange="updateJobStatusTableState(this.value);this.blur();">
                         {% for s in [
                             {"label": "all", "value": []},
@@ -56,21 +59,8 @@
                     </select>
                 </div>
                 <div class="input-group input-group-sm">
-                    <span class="input-group-text" style="width:40%">submit time</span>
-                    <select class="form-select" onchange="updateJobStatusTableSubmitTimeWindow(this.value);this.blur();">
-                        {% for t in [
-                            {"label": "all", "value": "all"},
-                            {"label": "last 6 hours", "value": "6h"},
-                            {"label": "last 1 day", "value": "1d"},
-                            {"label": "last 3 days", "value": "3d"},
-                            {"label": "last 7 days", "value": "7d"},
-                            {"label": "last 14 days", "value": "14d" },
-                        ] %}
-                        {% if t.value=="all" %}<option value="{{ t.value }}" selected>{{ t.label }}</option>
-                        {% else %}<option value="{{ t.value }}">{{ t.label }}</option>
-                        {% endif %}
-                        {% endfor %}
-                    </select>
+                    <span class="input-group-text" style="width:35%">Submit Time</span>
+                    <div id="submit-date-range" class="form-select"><span id="submit-date-range-text"></span></div>
                 </div>
             </div>
         </div>
@@ -106,36 +96,45 @@
         <iframe id="jobs-iframe" src="{{ url_for('job_status_table').include_query_params(limit=default_limit, offset=default_offset,state=default_state)}}"></iframe>
     </div>
     <script>
-        const SUBMIT_TIME_WINDOW_REGEX = /(\d+)([hd])/;
         const PaginateTo = {
             NEXT: 'next',
             PREV: 'prev',
             FIRST: 'first',
             LAST: 'last'
         };
+        // initialize date range picker for submit time
+        $(function () {
+            var today = moment();
+            var twoWeeksAgo = moment().subtract(13, 'days');
+            $('#submit-date-range').daterangepicker({
+                startDate: twoWeeksAgo,
+                endDate: today,
+                maxDate: today,
+                ranges: {
+                    'Today': [today, today],
+                    'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+                    'Last 3 Days': [moment().subtract(2, 'days'), today],
+                    'Last 7 Days': [moment().subtract(6, 'days'), today],
+                    'Last 14 Days': [twoWeeksAgo, today],
+                }
+            }, updateJobStatusTableSubmitTimeRange);
+            updateJobStatusTableSubmitTimeRange(twoWeeksAgo, today);
+        });
+        // event handlers for updating job status table
         function updateJobStatusTableState(newState) {
             var iframe = document.getElementById('jobs-iframe');
             var currentUrl = new URL(iframe.src);
             currentUrl.searchParams.set('state', newState);
             iframe.src = currentUrl.toString();
         }
-        function updateJobStatusTableSubmitTimeWindow(newWindow) {
+        function updateJobStatusTableSubmitTimeRange(start, end) {
+            document.getElementById('submit-date-range-text').innerText = `${start.format('YYYY-MM-DD')} to ${end.format('YYYY-MM-DD')}`;
+            var startDate = start.startOf('day').toISOString();
+            var endDate = end.endOf('day').toISOString();
             var iframe = document.getElementById('jobs-iframe');
             var currentUrl = new URL(iframe.src);
-            if (newWindow === "all") {
-                currentUrl.searchParams.delete('execution_date_gte');
-                console.log("currentUrl", currentUrl.toString());
-            } else {
-                // set new execution_date_gte for jobs submitted within the time window (e.g., 6h, 3d)
-                const match = newWindow.match(SUBMIT_TIME_WINDOW_REGEX);
-                if (!match) {
-                    console.error("Invalid time window format. Expected format: <number><h|d> (e.g., 6h, 1d, 3d, 7d, 14d)");
-                    return;
-                }
-                const [_, amount, unit] = match;
-                const execution_date_gte = moment().subtract(parseInt(amount), unit).toISOString();
-                currentUrl.searchParams.set('execution_date_gte', execution_date_gte);
-            }
+            currentUrl.searchParams.set('execution_date_gte', startDate);
+            currentUrl.searchParams.set('execution_date_lte', endDate);
             iframe.src = currentUrl.toString();
         }
         function updateJobStatusTableLimit(newLimit) {

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -45,12 +45,13 @@
             <div class="card-body p-2">
                 <div class="input-group input-group-sm mb-1">
                     <span class="input-group-text" style="width:35%">Status</span>
-                    <select class="form-select" onchange="updateJobStatusTableState(this.value);this.blur();">
+                    <select class="form-select" onchange="filterJobsByStatus(this.value);this.blur();">
                         {% for s in [
-                            {"label": "all", "value": []},
-                            {"label": "running", "value": ['running'], "class": "text-info"},
-                            {"label": "failed", "value": ['failed'], "class": "text-danger"},
-                            {"label": "success", "value": ['success'], "class": "text-success"},
+                            {"label": "all", "value": [], "class": "text-dark"},
+                            {"label": "queued", "value": ["queued"], "class": "text-secondary"},
+                            {"label": "running", "value": ["running"], "class": "text-info"},
+                            {"label": "failed", "value": ["failed"], "class": "text-danger"},
+                            {"label": "success", "value": ["success"], "class": "text-success"},
                         ] %}
                         {% if s.value==default_state %}<option class="{{ s.class }}" value="{{ s.value }}" selected>{{ s.label }}</option>
                         {% else %}<option class="{{ s.class }}" value="{{ s.value }}">{{ s.label }}</option>
@@ -60,7 +61,7 @@
                 </div>
                 <div class="input-group input-group-sm">
                     <span class="input-group-text" style="width:35%">Submit Time</span>
-                    <div id="submit-date-range" class="form-select"><span id="submit-date-range-text"></span></div>
+                    <input id="submit-date-range" class="form-select" type="text" />
                 </div>
             </div>
         </div>
@@ -93,7 +94,7 @@
             </div>
         </div>
         <!-- iframe to display paginated job status table -->
-        <iframe id="jobs-iframe" src="{{ url_for('job_status_table').include_query_params(limit=default_limit, offset=default_offset,state=default_state)}}"></iframe>
+        <iframe id="jobs-iframe" src=""></iframe>
     </div>
     <script>
         const PaginateTo = {
@@ -102,10 +103,11 @@
             FIRST: 'first',
             LAST: 'last'
         };
-        // initialize date range picker for submit time
-        $(function () {
-            var today = moment();
-            var twoWeeksAgo = moment().subtract(13, 'days');
+        $(document).ready(function() {
+            const today = moment();
+            const twoWeeksAgo = moment().subtract(13, 'days');
+            
+            // initialize daterangepicker for submit date filter
             $('#submit-date-range').daterangepicker({
                 startDate: twoWeeksAgo,
                 endDate: today,
@@ -113,36 +115,48 @@
                 maxDate: today,
                 ranges: {
                     'Today': [today, today],
-                    'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
                     'Last 3 Days': [moment().subtract(2, 'days'), today],
                     'Last 7 Days': [moment().subtract(6, 'days'), today],
                     'Last 14 Days': [twoWeeksAgo, today],
                 }
-            }, updateJobStatusTableSubmitTimeRange);
-            updateJobStatusTableSubmitTimeRange(twoWeeksAgo, today);
+            }, filterJobsBySubmitTimeRange);
+
+            // initialize job status table with default values
+            const initialParams = {
+                limit: "{{ default_limit }}",
+                offset: "{{ default_offset }}",
+                state: "{{ default_state }}",
+                // set default submit date range client-side for browser's local time
+                execution_date_gte: twoWeeksAgo.startOf('day').toISOString(),
+                execution_date_lte: today.endOf('day').toISOString(),
+            };
+            updateJobStatusTable(initialParams, true);
         });
-        // event handlers for updating job status table
-        function updateJobStatusTableState(newState) {
+        // EVENT HANDLERS ------------------------------------------------
+        function updateJobStatusTable(newParams, isInitial=false) {
             var iframe = document.getElementById('jobs-iframe');
-            var currentUrl = new URL(iframe.src);
-            currentUrl.searchParams.set('state', newState);
+            var currentUrl = isInitial ?  new URL("{{ url_for('job_status_table') }}") : new URL(iframe.src);
+            Object.entries(newParams).forEach(([key, value]) => {
+                currentUrl.searchParams.set(key, value);
+            });
             iframe.src = currentUrl.toString();
         }
-        function updateJobStatusTableSubmitTimeRange(start, end) {
-            document.getElementById('submit-date-range-text').innerText = `${start.format('YYYY-MM-DD')} to ${end.format('YYYY-MM-DD')}`;
-            var startDate = start.startOf('day').toISOString();
-            var endDate = end.endOf('day').toISOString();
-            var iframe = document.getElementById('jobs-iframe');
-            var currentUrl = new URL(iframe.src);
-            currentUrl.searchParams.set('execution_date_gte', startDate);
-            currentUrl.searchParams.set('execution_date_lte', endDate);
-            iframe.src = currentUrl.toString();
+        function filterJobsByStatus(newStatus) {
+            updateJobStatusTable({
+                state: newStatus,
+                offset: 0 // reset to first page
+            });
+        }
+        function filterJobsBySubmitTimeRange(start, end) {
+            // NOTE: daterangepicker already has 00:00:00.000 and 23:59:59.999 for start and end
+            updateJobStatusTable({
+                execution_date_gte: start.toISOString(),
+                execution_date_lte: end.toISOString(),
+                offset: 0 // reset to first page
+            });
         }
         function updateJobStatusTableLimit(newLimit) {
-            var iframe = document.getElementById('jobs-iframe');
-            var currentUrl = new URL(iframe.src);
-            currentUrl.searchParams.set('limit', newLimit);
-            iframe.src = currentUrl.toString();
+            updateJobStatusTable({limit: newLimit});
         }
         function updateJobStatusTablePage(paginateTo) {
             var iframe = document.getElementById('jobs-iframe');
@@ -165,8 +179,7 @@
                     offset = Math.floor(totalEntries / limit) * limit;
                     break;
             }
-            currentUrl.searchParams.set('offset', offset);
-            iframe.src = currentUrl.toString();
+            updateJobStatusTable({offset: offset});
         }
     </script>
     </body>

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -36,6 +36,44 @@
     <div class="content">
         <!-- display total entries from child iframe -->
         <h2 class="mb-3">Jobs Submitted: <span id="jobs-iframe-total-entries"></h2>
+        <!-- filters for job status results-->
+        <div class="card">
+            <div class="card-header">Filter by</div>
+            <div class="card-body">
+                <div class="input-group">
+                    <span class="input-group-text">status</span>
+                    <select class="form-select" onchange="updateJobStatusTableState(this.value);this.blur();">
+                        {% for s in [
+                            {"label": "all", "value": []},
+                            {"label": "running", "value": ['running']},
+                            {"label": "failed", "value": ['failed']},
+                            {"label": "success", "value": ['success']},
+                        ] %}
+                        {% if s.value==default_state %}<option value="{{ s.value }}" selected>{{ s.label }}</option>
+                        {% else %}<option value="{{ s.value }}">{{ s.label }}</option>
+                        {% endif %}
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="input-group">
+                    <span class="input-group-text">submit time</span>
+                    <select class="form-select" onchange="updateJobStatusTableSubmitTimeWindow(this.value);this.blur();">
+                        {% for t in [
+                            {"label": "all", "value": "all"},
+                            {"label": "last 6 hours", "value": "6h"},
+                            {"label": "last 1 day", "value": "1d"},
+                            {"label": "last 3 days", "value": "3d"},
+                            {"label": "last 7 days", "value": "7d"},
+                            {"label": "last 14 days", "value": "14d" },
+                        ] %}
+                        {% if t.value=="all" %}<option value="{{ t.value }}" selected>{{ t.label }}</option>
+                        {% else %}<option value="{{ t.value }}">{{ t.label }}</option>
+                        {% endif %}
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+        </div>
         <!-- toolbar to change jobs per page and navigate pages -->
         <div id="jobs-toolbar" class="btn-toolbar justify-content-between mb-2" role="toolbar">
             <div class="input-group">
@@ -47,38 +85,6 @@
                     {% endfor %}
                 </select>
                 <span class="input-group-text">jobs per page</span>
-            </div>
-            <div class="input-group">
-                <select class="form-select" onchange="updateJobStatusTableState(this.value);this.blur();">
-                    {% for s in [
-                        {"label": "all", "value": []},
-                        {"label": "running", "value": ['running']},
-                        {"label": "failed", "value": ['failed']},
-                        {"label": "success", "value": ['success']},
-                    ] %}
-                    {% if s.value==default_state %}<option value="{{ s.value }}" selected>{{ s.label }}</option>
-                    {% else %}<option value="{{ s.value }}">{{ s.label }}</option>
-                    {% endif %}
-                    {% endfor %}
-                </select>
-                <span class="input-group-text">status</span>
-            </div>
-            <div class="input-group">
-                <select class="form-select" onchange="updateJobStatusTableSubmitTimeWindow(this.value);this.blur();">
-                    {% for t in [
-                        {"label": "all", "value": "all"},
-                        {"label": "last 6 hours", "value": "6h"},
-                        {"label": "last 1 day", "value": "1d"},
-                        {"label": "last 3 days", "value": "3d"},
-                        {"label": "last 7 days", "value": "7d"},
-                        {"label": "last 14 days", "value": "14d" },
-                    ] %}
-                    {% if t.value=="all" %}<option value="{{ t.value }}" selected>{{ t.label }}</option>
-                    {% else %}<option value="{{ t.value }}">{{ t.label }}</option>
-                    {% endif %}
-                    {% endfor %}
-                </select>
-                <span class="input-group-text">submit time</span>
             </div>
             <div class="btn-group" role="group">
                 <!-- display current jobs range e.g, "1 to 10 of 100" -->

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -20,7 +20,7 @@
         }
         .content {
             width: 100%;
-            height: calc(100vh - 300px);
+            height: calc(100vh - 250px);
             iframe {
                 border: none;
                 width: 100%;
@@ -41,9 +41,12 @@
         <!-- display total entries from child iframe -->
         <h2 class="mb-2">Jobs Submitted: <span id="jobs-iframe-total-entries"></h2>
         <!-- filters for job status results-->
-        <div class="card mb-4" style="width:380px">
-            <div class="card-header py-1">Filter by</div>
-            <div class="card-body p-2">
+        <div class="card mb-4" style="width:400px">
+            <div class="card-header py-1" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-filters" aria-expanded="false" aria-controls="collapse-filters">
+                <i class="bi bi-filter"></i><span class="ms-2">Filter by</span>
+                <i class="bi bi-chevron-expand float-end"></i>
+            </div>
+            <div id="collapse-filters" class="collapse card-body p-2">
                 <!-- filter by job status -->
                 <div class="input-group input-group-sm mb-1">
                     <span class="input-group-text" style="width:35%">Status</span>

--- a/src/aind_data_transfer_service/templates/job_status_table.html
+++ b/src/aind_data_transfer_service/templates/job_status_table.html
@@ -27,6 +27,7 @@
       <td class="{% if job_status.job_state == 'success' %}table-success
                 {% elif job_status.job_state == 'failed' %}table-danger
                 {% elif job_status.job_state == 'running' %}table-info
+                {% elif job_status.job_state == 'queued' %}table-secondary
                 {% endif %}">{{job_status.job_state}}</td>
       <td class="datetime_to_be_adjusted">{{job_status.submit_time}}</td>
       <td class="datetime_to_be_adjusted">{{job_status.start_time}}</td>
@@ -63,7 +64,7 @@
         limit = parseInt('{{limit}}');
         total_entries = parseInt('{{total_entries}}');
         parent.document.getElementById('jobs-iframe-total-entries').innerText = '{{total_entries}}';
-        parent.document.getElementById('jobs-iframe-showing').innerText = `${offset + 1} to ${Math.min(offset + limit, total_entries)} of ${total_entries}`;
+        parent.document.getElementById('jobs-iframe-showing').innerText = `${(total_entries > 0) ? (offset + 1) : offset} to ${Math.min(offset + limit, total_entries)} of ${total_entries}`;
         // also update the pagination buttons
         isFirst = (offset == 0);
         isLast = (offset + limit >= total_entries);

--- a/src/aind_data_transfer_service/templates/job_status_table.html
+++ b/src/aind_data_transfer_service/templates/job_status_table.html
@@ -64,10 +64,12 @@
         limit = parseInt('{{limit}}');
         total_entries = parseInt('{{total_entries}}');
         parent.document.getElementById('jobs-iframe-total-entries').innerText = '{{total_entries}}';
-        parent.document.getElementById('jobs-iframe-showing').innerText = `${(total_entries > 0) ? (offset + 1) : offset} to ${Math.min(offset + limit, total_entries)} of ${total_entries}`;
+        parent.document.getElementById('jobs-iframe-showing').innerText = (total_entries > 1)
+          ? `${offset + 1} to ${Math.min(offset + limit, total_entries)} of ${total_entries}`
+          : `${total_entries} to ${total_entries} of ${total_entries}`;
         // also update the pagination buttons
-        isFirst = (offset == 0);
-        isLast = (offset + limit >= total_entries);
+        isFirst = (total_entries > 1) ? (offset == 0) : true;
+        isLast = (total_entries > 1) ? (offset + limit >= total_entries) : true;
         parent.document.getElementById('jobs-page-btn-first').disabled = isFirst;
         parent.document.getElementById('jobs-page-btn-prev').disabled = isFirst;
         parent.document.getElementById('jobs-page-btn-next').disabled = isLast;

--- a/tests/resources/airflow_dag_run_response.json
+++ b/tests/resources/airflow_dag_run_response.json
@@ -1,0 +1,51 @@
+{
+  "conf": {
+     "acq_datetime": "2000-01-01T01:40:03",
+     "force_cloud_sync": false,
+     "metadata_dir": null,
+     "metadata_dir_force": false,
+     "modalities": [
+        {
+           "compress_raw_data": true,
+           "extra_configs": null,
+           "modality": {
+              "abbreviation": "ecephys",
+              "name": "Extracellular electrophysiology"
+           },
+           "slurm_settings": null,
+           "source": "/a_source/ecephys"
+        },
+        {
+           "compress_raw_data": false,
+           "extra_configs": null,
+           "modality": {
+              "abbreviation": "behavior-videos",
+              "name": "Behavior videos"
+           },
+           "slurm_settings": null,
+           "source": "/b_source/ecephys"
+        }
+     ],
+     "platform": {
+        "abbreviation": "ecephys",
+        "name": "Electrophysiology platform"
+     },
+     "process_capsule_id": null,
+     "project_name": "Ephys Platform",
+     "s3_bucket": "private",
+     "subject_id": "655019"
+  },
+  "dag_id": "transform_and_upload",
+  "dag_run_id": "manual__2024-05-18T22:08:52.286765+00:00",
+  "data_interval_end": "2024-05-18T22:08:52.286765+00:00",
+  "data_interval_start": "2024-05-18T22:08:52.286765+00:00",
+  "end_date": "2024-05-18T22:09:28.530534+00:00",
+  "execution_date": "2024-05-18T22:08:52.286765+00:00",
+  "external_trigger": true,
+  "last_scheduling_decision": "2024-05-18T22:09:28.527134+00:00",
+  "logical_date": "2024-05-18T22:08:52.286765+00:00",
+  "note": null,
+  "run_type": "manual",
+  "start_date": "2024-05-18T22:08:52.637098+00:00",
+  "state": "failed"
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -541,8 +541,7 @@ class TestServer(unittest.TestCase):
         expected_default_params = {
             "limit": 25,
             "offset": 0,
-            "start_date_gte": "mock_start_date_gte",
-            "order_by": "-start_date",
+            "order_by": "-execution_date",
         }
         expected_job_status_list = [
             {
@@ -594,10 +593,6 @@ class TestServer(unittest.TestCase):
         with TestClient(app) as client:
             response = client.get("/api/v1/get_job_status_list")
         response_content = response.json()
-        # small hack to mock the date
-        response_content["data"]["params"][
-            "start_date_gte"
-        ] = "mock_start_date_gte"
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response_content,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,7 @@ import json
 import os
 import unittest
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock, patch
@@ -43,8 +43,11 @@ MOCK_DB_FILE = TEST_DIRECTORY / "test_server" / "db.json"
 NEW_SAMPLE_CSV = TEST_DIRECTORY / "resources" / "new_sample.csv"
 MALFORMED_SAMPLE2_CSV = TEST_DIRECTORY / "resources" / "sample_malformed_2.csv"
 
-DAG_RUN_RESPONSE = (
+LIST_DAG_RUNS_RESPONSE = (
     TEST_DIRECTORY / "resources" / "airflow_dag_runs_response.json"
+)
+GET_DAG_RUN_RESPONSE = (
+    TEST_DIRECTORY / "resources" / "airflow_dag_run_response.json"
 )
 
 
@@ -69,6 +72,7 @@ class TestServer(unittest.TestCase):
         "HPC_AWS_PARAM_STORE_NAME": "/some/param/store",
         "OPEN_DATA_AWS_SECRET_ACCESS_KEY": "open_data_aws_key",
         "OPEN_DATA_AWS_ACCESS_KEY_ID": "open_data_aws_key_id",
+        "AIND_AIRFLOW_SERVICE_JOBS_URL": "airflow_jobs_url",
     }
 
     with open(SAMPLE_CSV, "r") as file:
@@ -77,8 +81,11 @@ class TestServer(unittest.TestCase):
     with open(MOCK_DB_FILE) as f:
         json_contents = json.load(f)
 
-    with open(DAG_RUN_RESPONSE) as f:
-        dag_run_response = json.load(f)
+    with open(LIST_DAG_RUNS_RESPONSE) as f:
+        list_dag_runs_response = json.load(f)
+
+    with open(GET_DAG_RUN_RESPONSE) as f:
+        get_dag_run_response = json.load(f)
 
     expected_job_configs = deepcopy(TestJobConfigs.expected_job_configs)
     for config in expected_job_configs:
@@ -534,13 +541,16 @@ class TestServer(unittest.TestCase):
         mock_dag_runs_response = Response()
         mock_dag_runs_response.status_code = 200
         mock_dag_runs_response._content = json.dumps(
-            self.dag_run_response
+            self.list_dag_runs_response
         ).encode("utf-8")
         mock_get.return_value = mock_dag_runs_response
         expected_message = "Retrieved job status list from airflow"
         expected_default_params = {
             "limit": 25,
             "offset": 0,
+            "state": [],
+            "execution_date_gte": "mock_execution_date_gte",
+            "execution_date_lte": None,
             "order_by": "-execution_date",
         }
         expected_job_status_list = [
@@ -593,6 +603,10 @@ class TestServer(unittest.TestCase):
         with TestClient(app) as client:
             response = client.get("/api/v1/get_job_status_list")
         response_content = response.json()
+        # small hack to mock the date
+        response_content["data"]["params"][
+            "execution_date_gte"
+        ] = "mock_execution_date_gte"
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response_content,
@@ -600,7 +614,9 @@ class TestServer(unittest.TestCase):
                 "message": expected_message,
                 "data": {
                     "params": expected_default_params,
-                    "total_entries": self.dag_run_response["total_entries"],
+                    "total_entries": self.list_dag_runs_response[
+                        "total_entries"
+                    ],
                     "job_status_list": expected_job_status_list,
                 },
             },
@@ -617,13 +633,20 @@ class TestServer(unittest.TestCase):
         mock_dag_runs_response = Response()
         mock_dag_runs_response.status_code = 200
         mock_dag_runs_response._content = json.dumps(
-            self.dag_run_response
+            self.list_dag_runs_response
         ).encode("utf-8")
         mock_get.return_value = mock_dag_runs_response
         expected_message = "Retrieved job status list from airflow"
         with TestClient(app) as client:
             response = client.get(
-                "/api/v1/get_job_status_list?limit=10&offset=5"
+                "/api/v1/get_job_status_list",
+                params={
+                    "limit": 10,
+                    "offset": 5,
+                    "execution_date_gte": (
+                        datetime.now(timezone.utc) - timedelta(days=2)
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                },
             )
         response_content = response.json()
         self.assertEqual(response.status_code, 200)
@@ -632,22 +655,86 @@ class TestServer(unittest.TestCase):
         self.assertEqual(response_content["data"]["params"]["offset"], 5)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    @patch("requests.get")
     @patch("logging.error")
     def test_get_job_status_list_validation_error(
         self,
         mock_log_error: MagicMock,
+        mock_get,
     ):
         """Tests get_job_status_list when query_params are invalid."""
+        invalid_queries = [
+            {"limit": "invalid", "offset": 5},
+            {"limit": 5, "offset": "invalid"},
+            {
+                "execution_date_gte": (
+                    datetime.now(timezone.utc)
+                    - timedelta(weeks=2)
+                    - timedelta(minutes=1)
+                ).strftime("%Y-%m-%dT%H:%M:%SZ")
+            },
+        ]
+        for query in invalid_queries:
+            with TestClient(app) as client:
+                response = client.get(
+                    "/api/v1/get_job_status_list", params=query
+                )
+            response_content = response.json()
+            self.assertEqual(response.status_code, 406)
+            self.assertEqual(
+                response_content["message"],
+                "Error validating request parameters",
+            )
+        mock_log_error.assert_called()
+        mock_get.assert_not_called()
+
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    @patch("requests.get")
+    def test_get_job_status_list_dag_run_id(
+        self,
+        mock_get,
+    ):
+        """Tests get_job_status_list gets 1 dagRun from airflow when dag_run_id
+        is provided."""
+        dag_run_id = "manual__2024-05-18T22:08:52.286765+00:00"
+        mock_dag_run_response = Response()
+        mock_dag_run_response.status_code = 200
+        mock_dag_run_response._content = json.dumps(
+            self.get_dag_run_response
+        ).encode("utf-8")
+        mock_get.return_value = mock_dag_run_response
+        expected_message = "Retrieved job status list from airflow"
+        expected_params = {
+            "dag_run_id": dag_run_id,
+        }
+        expected_job_status_list = [
+            {
+                "end_time": "2024-05-18T22:09:28.530534Z",
+                "job_id": "manual__2024-05-18T22:08:52.286765+00:00",
+                "job_state": "failed",
+                "name": "",
+                "comment": None,
+                "start_time": "2024-05-18T22:08:52.637098Z",
+                "submit_time": "2024-05-18T22:08:52.286765Z",
+            },
+        ]
         with TestClient(app) as client:
             response = client.get(
-                "/api/v1/get_job_status_list?limit=invalid&offset=5"
+                "/api/v1/get_job_status_list", params=expected_params
             )
         response_content = response.json()
-        self.assertEqual(response.status_code, 406)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response_content["message"], "Error validating request parameters"
+            response_content,
+            {
+                "message": expected_message,
+                "data": {
+                    "params": expected_params,
+                    "total_entries": 1,
+                    "job_status_list": expected_job_status_list,
+                },
+            },
         )
-        mock_log_error.assert_called_once()
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("logging.error")
@@ -690,9 +777,9 @@ class TestServer(unittest.TestCase):
         """Tests that job status table renders as expected."""
         mock_response = Response()
         mock_response.status_code = 200
-        mock_response._content = json.dumps(self.dag_run_response).encode(
-            "utf-8"
-        )
+        mock_response._content = json.dumps(
+            self.list_dag_runs_response
+        ).encode("utf-8")
         mock_get.return_value = mock_response
         with TestClient(app) as client:
             response = client.get("/job_status_table")


### PR DESCRIPTION
closes #128

- Add collapsable Filters UI to filter jobs by  **status**, **submit date range**
    - or, search by **job id** (exact match only)
- Update `/api/v1/get_job_status_list`:
    - Query filters for `state`, `execution_date_lte`, `execution_date_gte` (must be within 14 days), and `dag_run_id`
    - Uses Airflow ListDagRuns and GetDagRun

---
**Default**:
![image](https://github.com/user-attachments/assets/01a60395-61f4-428d-a629-7db2eb5575e0)
---
**Filter job status:**
![image](https://github.com/user-attachments/assets/d4bf5ef7-a7b4-4ada-8c8e-fd1799f01cb7)
---
**Filter by submit date range:**
![image](https://github.com/user-attachments/assets/be5d1929-3f2e-44bc-889d-45df5821261e)
---
**Search by job id:**
![image](https://github.com/user-attachments/assets/4b9f00af-f289-40c3-95d6-c593617fe711)
---
**Job id not found:**
![image](https://github.com/user-attachments/assets/46ed5c56-8cf4-4d17-96fe-c2d3b6166d04)
---