### PR TITLE
fix: round_trip validation issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     'pydantic>=2.7,<2.9',
     'pydantic-settings>=2.0',
     'aind-data-schema>=1.0.0',
-    'aind-data-transfer-models==0.8.4'
+    'aind-data-transfer-models==0.8.5'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #158

- Updates aind-data-transfer-models version, which has a validation wrapper to allow for computed_fields such as s3_prefix to present in the json object being de-serialized.