### PR TITLE
feat: endpoint to validate json

### DIFF
--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -151,6 +151,10 @@ endpoint:
   )
 
   post_request_content = json.loads(submit_request.model_dump_json(exclude_none=True))
+  # Optionally validate the submit_request before submitting
+  validate_job_response = requests.post(url="http://aind-data-transfer-service/api/v1/models/SubmitJobRequest/validate", json=post_request_content)
+  print(submit_job_response.status_code)
+  print(submit_job_response.json())
   # Uncomment the following to submit the request
   # submit_job_response = requests.post(url="http://aind-data-transfer-service/api/v1/submit_jobs", json=post_request_content)
   # print(submit_job_response.status_code)

--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -153,8 +153,8 @@ endpoint:
   post_request_content = json.loads(submit_request.model_dump_json(exclude_none=True))
   # Optionally validate the submit_request before submitting
   validate_job_response = requests.post(url="http://aind-data-transfer-service/api/v1/models/SubmitJobRequest/validate", json=post_request_content)
-  print(submit_job_response.status_code)
-  print(submit_job_response.json())
+  print(validate_job_response.status_code)
+  print(validate_job_response.json())
   # Uncomment the following to submit the request
   # submit_job_response = requests.post(url="http://aind-data-transfer-service/api/v1/submit_jobs", json=post_request_content)
   # print(submit_job_response.status_code)

--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -152,7 +152,7 @@ endpoint:
 
   post_request_content = json.loads(submit_request.model_dump_json(exclude_none=True))
   # Optionally validate the submit_request before submitting
-  validate_job_response = requests.post(url="http://aind-data-transfer-service/api/v1/models/SubmitJobRequest/validate", json=post_request_content)
+  validate_job_response = requests.post(url="http://aind-data-transfer-service/api/v1/validate_json", json=post_request_content)
   print(validate_job_response.status_code)
   print(validate_job_response.json())
   # Uncomment the following to submit the request

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -4,7 +4,19 @@ import ast
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Union
 
-from pydantic import AwareDatetime, BaseModel, Field, field_validator
+from aind_data_transfer_models.core import (
+    BasicUploadJobConfigs,
+    ModalityConfigs,
+    SubmitJobRequest,
+)
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+)
+from pydantic.json_schema import SkipJsonSchema
 from starlette.datastructures import QueryParams
 
 
@@ -212,3 +224,40 @@ class JobTasks(BaseModel):
             duration=airflow_task_instance.duration,
             comment=airflow_task_instance.note,
         )
+
+
+class ModalityConfigsForm(ModalityConfigs):
+    """Configurations for a modality type"""
+
+    model_config = ConfigDict(extra="forbid")
+    job_settings: Optional[str] = Field(
+        default=None,
+        description=(
+            "Configs to pass into modality compression job. "
+            "Must be serialized as json string."
+        ),
+    )
+    # remove from json schema:
+    slurm_settings: SkipJsonSchema[None] = None
+
+
+class BasicUploadJobConfigsForm(BasicUploadJobConfigs):
+    """Configuration for a basic upload job"""
+
+    model_config = ConfigDict(extra="forbid")
+    modalities: List[ModalityConfigsForm]
+    # remove from json schema:
+    user_email: SkipJsonSchema[None] = None
+    email_notification_types: SkipJsonSchema[None] = None
+    input_data_mount: SkipJsonSchema[None] = None
+    process_capsule_id: SkipJsonSchema[None] = None
+    trigger_capsule_configs: SkipJsonSchema[None] = None
+
+
+class SubmitJobRequestForm(SubmitJobRequest):
+    """Form to submit a list of jobs to aind-data-transfer-service"""
+
+    model_config = ConfigDict(extra="forbid")
+    upload_jobs: List[BasicUploadJobConfigsForm]
+    # remove from json schema:
+    job_type: SkipJsonSchema[None] = None

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -4,19 +4,7 @@ import ast
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Union
 
-from aind_data_transfer_models.core import (
-    BasicUploadJobConfigs,
-    ModalityConfigs,
-    SubmitJobRequest,
-)
-from pydantic import (
-    AwareDatetime,
-    BaseModel,
-    ConfigDict,
-    Field,
-    field_validator,
-)
-from pydantic.json_schema import SkipJsonSchema
+from pydantic import AwareDatetime, BaseModel, Field, field_validator
 from starlette.datastructures import QueryParams
 
 
@@ -224,40 +212,3 @@ class JobTasks(BaseModel):
             duration=airflow_task_instance.duration,
             comment=airflow_task_instance.note,
         )
-
-
-class ModalityConfigsForm(ModalityConfigs):
-    """Configurations for a modality type"""
-
-    model_config = ConfigDict(extra="forbid")
-    job_settings: Optional[str] = Field(
-        default=None,
-        description=(
-            "Configs to pass into modality compression job. "
-            "Must be serialized as json string."
-        ),
-    )
-    # remove from json schema:
-    slurm_settings: SkipJsonSchema[None] = None
-
-
-class BasicUploadJobConfigsForm(BasicUploadJobConfigs):
-    """Configuration for a basic upload job"""
-
-    model_config = ConfigDict(extra="forbid")
-    modalities: List[ModalityConfigsForm]
-    # remove from json schema:
-    user_email: SkipJsonSchema[None] = None
-    email_notification_types: SkipJsonSchema[None] = None
-    input_data_mount: SkipJsonSchema[None] = None
-    process_capsule_id: SkipJsonSchema[None] = None
-    trigger_capsule_configs: SkipJsonSchema[None] = None
-
-
-class SubmitJobRequestForm(SubmitJobRequest):
-    """Form to submit a list of jobs to aind-data-transfer-service"""
-
-    model_config = ConfigDict(extra="forbid")
-    upload_jobs: List[BasicUploadJobConfigsForm]
-    # remove from json schema:
-    job_type: SkipJsonSchema[None] = None

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -72,7 +72,6 @@ templates = Jinja2Templates(directory=template_directory)
 # AIND_AIRFLOW_SERVICE_PASSWORD
 # AIND_AIRFLOW_SERVICE_USER
 
-# NOTE: add cors to test metadata-entry-app
 middleware = [
     Middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"])
 ]

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -40,6 +40,8 @@ from aind_data_transfer_service.models import (
     JobStatus,
     JobTasks,
 )
+from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware import Middleware
 
 template_directory = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "templates")
@@ -65,6 +67,10 @@ templates = Jinja2Templates(directory=template_directory)
 # AIND_AIRFLOW_SERVICE_PASSWORD
 # AIND_AIRFLOW_SERVICE_USER
 
+# NOTE: add cors to test metadata-entry-app
+middleware = [
+    Middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"])
+]
 
 async def validate_csv(request: Request):
     """Validate a csv or xlsx file. Return parsed contents as json."""
@@ -826,4 +832,4 @@ routes = [
     ),
 ]
 
-app = Starlette(routes=routes)
+app = Starlette(routes=routes, middleware=middleware)

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -182,6 +182,7 @@ async def validate_json_for_model(request: Request):
     json or errors if request is invalid."""
     # POST /api/v1/models/{model_name}/validate
     model_name = request.path_params.get("model_name")
+    logger.info(f"Received request to validate json for {model_name}")
     content = await request.json()
     if model_name == "BasicUploadJobConfigs":
         model = BasicUploadJobConfigs
@@ -190,6 +191,7 @@ async def validate_json_for_model(request: Request):
     elif model_name == "SubmitJobRequest":
         model = SubmitJobRequest
     else:
+        logger.warning(f"Model not found for {model_name}")
         return JSONResponse(
             status_code=404,
             content={
@@ -201,6 +203,7 @@ async def validate_json_for_model(request: Request):
         validated_content = json.loads(
             validated_model.model_dump_json(warnings=False, exclude_none=True)
         )
+        logger.info(f"Valid model detected for {model_name}")
         return JSONResponse(
             status_code=200,
             content={
@@ -212,6 +215,7 @@ async def validate_json_for_model(request: Request):
             },
         )
     except ValidationError as e:
+        logger.warning(f"There were validation errors processing {content}")
         return JSONResponse(
             status_code=406,
             content={
@@ -223,6 +227,7 @@ async def validate_json_for_model(request: Request):
             },
         )
     except Exception as e:
+        logger.exception("Internal Server Error.")
         return JSONResponse(
             status_code=500,
             content={


### PR DESCRIPTION
closes #195 (rescoped from #107)

This PR introduces a new endpoint to validate raw json against aind-data-transfer-models.
- POST `/api/v1/validate_json`
- Example added in User Guide