### PR TITLE
feat: search all jobs by asset name or job id

### DIFF
--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -67,18 +67,6 @@ class AirflowDagRunsRequestParameters(BaseModel):
         return cls.model_validate(params)
 
 
-class AirflowDagRunRequestParameters(BaseModel):
-    """Model for parameters when requesting info from dag_run endpoint"""
-
-    dag_run_id: str = Field(..., min_length=1)
-
-    @classmethod
-    def from_query_params(cls, query_params: QueryParams):
-        """Maps the query parameters to the model"""
-        params = dict(query_params)
-        return cls.model_validate(params)
-
-
 class AirflowTaskInstancesRequestParameters(BaseModel):
     """Model for parameters when requesting info from task_instances
     endpoint"""

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -4,14 +4,16 @@ import csv
 import io
 import json
 import os
-from asyncio import sleep
+from asyncio import gather, sleep
 from pathlib import PurePosixPath
+from typing import Optional
 
 import requests
 from aind_data_transfer_models.core import SubmitJobRequest
 from fastapi import Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
+from httpx import AsyncClient
 from openpyxl import load_workbook
 from pydantic import SecretStr, ValidationError
 from starlette.applications import Starlette
@@ -422,10 +424,16 @@ async def submit_hpc_jobs(request: Request):  # noqa: C901
 
 async def get_job_status_list(request: Request):
     """Get status of jobs with default pagination of limit=25 and offset=0."""
-    # TODO: Use httpx async client
+    async def fetch_jobs(client: AsyncClient, url: str, params: Optional[dict]):
+        """Helper method to fetch jobs using httpx async client"""
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+        return response.json()
+    
     try:
         url = os.getenv("AIND_AIRFLOW_SERVICE_JOBS_URL", "").strip("/")
         get_one_job = request.query_params.get("dag_run_id") is not None
+        get_all_jobs = request.query_params.get("get_all_jobs") is not None
         if get_one_job:
             params = AirflowDagRunRequestParameters.from_query_params(
                 request.query_params
@@ -435,46 +443,72 @@ async def get_job_status_list(request: Request):
             params = AirflowDagRunsRequestParameters.from_query_params(
                 request.query_params
             )
-        params_dict = json.loads(params.model_dump_json())
+        params_dict = json.loads(params.model_dump_json(exclude_none=True))
         # Send request to Airflow to ListDagRuns or GetDagRun
-        response_jobs = requests.get(
-            url=url,
+        async with AsyncClient(
             auth=(
                 os.getenv("AIND_AIRFLOW_SERVICE_USER"),
                 os.getenv("AIND_AIRFLOW_SERVICE_PASSWORD"),
-            ),
-            params=None if get_one_job else params_dict,
-        )
-        status_code = response_jobs.status_code
-        if response_jobs.status_code == 200:
+            )
+        ) as client:
+            # Fetch initial jobs
+            response_jobs = await fetch_jobs(
+                client=client,
+                url=url,
+                params=None if get_one_job else params_dict,
+            )
             if get_one_job:
                 dag_run = AirflowDagRun.model_validate_json(
-                    json.dumps(response_jobs.json())
+                    json.dumps(response_jobs)
                 )
                 dag_runs = AirflowDagRunsResponse(
                     dag_runs=[dag_run], total_entries=1
                 )
             else:
                 dag_runs = AirflowDagRunsResponse.model_validate_json(
-                    json.dumps(response_jobs.json())
+                    json.dumps(response_jobs)
                 )
             job_status_list = [
                 JobStatus.from_airflow_dag_run(d) for d in dag_runs.dag_runs
             ]
-            message = "Retrieved job status list from airflow"
-            data = {
-                "params": params_dict,
-                "total_entries": dag_runs.total_entries,
-                "job_status_list": [
-                    json.loads(j.model_dump_json()) for j in job_status_list
-                ],
-            }
-        else:
-            message = "Error retrieving job status list from airflow"
-            data = {
-                "params": params_dict,
-                "errors": [response_jobs.json()],
-            }
+            total_entries = dag_runs.total_entries
+            if get_all_jobs:
+                # Fetch remaining jobs concurrently
+                tasks = []
+                offset = params_dict["offset"] + params_dict["limit"]
+                while offset < total_entries:
+                    tasks.append(
+                        fetch_jobs(
+                            client=client,
+                            url=url,
+                            params={
+                                **params_dict,
+                                "limit": 100,  # max limit in airflow
+                                "offset": offset,
+                            },
+                        )
+                    )
+                    offset += 100
+                batches = await gather(*tasks)
+                for batch in batches:
+                    dag_runs = AirflowDagRunsResponse.model_validate_json(
+                        json.dumps(batch)
+                    )
+                    job_status_list.extend(
+                        [
+                            JobStatus.from_airflow_dag_run(d)
+                            for d in dag_runs.dag_runs
+                        ]
+                    )
+        status_code = 200
+        message = "Retrieved job status list from airflow"
+        data = {
+            "params": params_dict,
+            "total_entries": total_entries,
+            "job_status_list": [
+                json.loads(j.model_dump_json()) for j in job_status_list
+            ],
+        }
     except ValidationError as e:
         logger.warning(
             f"There was a validation error process job_status list: {e}"

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -71,24 +71,15 @@
                     <span class="input-group-text" style="width:35%">Submit Time</span>
                     <input id="submit-date-range" class="form-select" type="text" />
                 </div>
-                <!-- search by job id (exact match only) -->
-                <div class="d-flex align-items-center">
-                    <hr class="flex-grow-1 border-secondary">
-                    <span class="mx-2"><small class="d-block">or</small></span>
-                    <hr class="flex-grow-1 border-secondary">
+                <!-- advanced search (uses full jobs table)-->
+                <hr class="flex-grow-1 border-secondary">
+                <div class="input-group input-group-sm mb-1">
+                    <span class="input-group-text" style="width:35%">Search</span>
+                    <input id="advanced-search-input" type="text" class="form-control" placeholder="asset name or job id" oninput="searchFullJobsTable(event)"/>
+                    <button id="advanced-search-clear" class="btn btn-outline-secondary" type="button" title="Clear" onclick="clearAdvancedSearch(event)">
+                        <i class="bi bi-x-lg"></i>
+                    </button>
                 </div>
-                <form onsubmit="searchByJobId(event)">
-                    <div class="input-group input-group-sm">
-                        <span class="input-group-text" style="width:35%">Job ID</span>
-                        <input id="job-id-input" type="text" class="form-control" placeholder="exact match only">
-                        <button class="btn btn-outline-secondary" type="submit" title="Search">
-                            <i class="bi bi-search"></i>
-                        </button>
-                        <button class="btn btn-outline-secondary" type="button" onclick="clearJobIdResult(event)" title="Clear">
-                            <i class="bi bi-x-lg"></i>
-                        </button>
-                    </div>
-                </form>
             </div>
         </div>
         <!-- job status tables -->
@@ -205,7 +196,7 @@
             });
         }
         // EVENT HANDLERS ------------------------------------------------
-        function updateJobStatusTable(newParams, isSearchJobId=false) {
+        function updateJobStatusTable(newParams) {
             Object.entries(newParams).forEach(([key, value]) => {
                 tableUrls.default.searchParams.set(key, value);
                 // Ignore paginate changes for full jobs table
@@ -213,11 +204,6 @@
                     tableUrls.full.searchParams.set(key, value);
                 }
             });
-            // reset job_id filter
-            if (!isSearchJobId) {
-                document.getElementById('job-id-input').value = '';
-                tableUrls.default.searchParams.delete('dag_run_id');
-            }
             // Update job tables
             var iframe = document.getElementById('jobs-iframe');
             iframe.src = tableUrls.default.toString();
@@ -242,17 +228,16 @@
                 offset: 0 // reset to first page
             });
         }
-        function searchByJobId(event) {
+        // Advanced search (full table)
+        function searchFullJobsTable(event) {
             event.preventDefault();
-            // search by job id and reset to first page
-            const jobId = document.getElementById('job-id-input').value;
-            console.log('Searching for job ID:', jobId);
-            updateJobStatusTable({ dag_run_id: jobId, offset: 0}, true);
+            let searchValue = event.target.value;
+            $('#searchJobsTable').DataTable().search(searchValue).draw();
         }
-        function clearJobIdResult(event) {
+        function clearAdvancedSearch(event) {
             event.preventDefault();
-            // clear job id filter and reset to first page
-            updateJobStatusTable({ offset: 0 }, false);
+            $('#advanced-search-input').val('');
+            $('#searchJobsTable').DataTable().search('').draw();
         }
         // Pagination (default table)
         function updateJobStatusTableLimit(newLimit) {

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -180,6 +180,29 @@
             updateJobStatusTable(initialParams);
         });
         // FULL JOBS TABLE -----------------------------------------------
+        // Helper functions for custom column rendering
+        function renderJobStatus(cell, cellData, rowData, rowIndex, colIndex) {
+            let customClass = cellData === 'success' ? 'table-success'
+                : cellData === 'failed' ? 'table-danger'
+                : cellData === 'running' ? 'table-info'
+                : cellData === 'queued' ? 'table-secondary'
+                : null;
+            if (customClass) {
+                cell.classList.add(customClass);
+            }
+        }
+        function renderDatetime(data, type, row) {
+            return (type === 'display') ? moment.utc(data).local().format('YYYY-MM-DD h:mm:ss a') : data;
+        }
+        function renderTasksButton(data, type, row) {
+            if (type == 'display') {
+                return (`<button type="button" class="btn btn-outline-primary btn-sm" data-bs-toggle="modal" data-bs-target="#tasks-modal" data-job-id="${data}" data-job-name="${row.name}" data-job-state="${row.job_state}">
+                    <i class="bi bi-box-arrow-up-right" title="View tasks and logs"></i>
+                    </button>`);
+            }
+            return data;
+        }
+        // Create DataTable for full jobs table
         function createFullJobsTable() {
             $('#searchJobsTable').DataTable({
                 ajax: {
@@ -190,13 +213,38 @@
                 columns: [
                     { data: 'name', searchable: true },
                     { data: 'job_id', searchable: true },
-                    { data: 'job_state', searchable: false },
-                    { data: 'submit_time', searchable: false },
-                    { data: 'start_time', searchable: false },
-                    { data: 'end_time', searchable: false },
-                    { data: 'comment', searchable: false },
-                    { data: 'job_id', searchable: false },
+                    { data: 'job_state', searchable: false, createdCell: renderJobStatus },
+                    { data: 'submit_time', searchable: false, render: renderDatetime },
+                    { data: 'start_time', searchable: false, render: renderDatetime },
+                    { data: 'end_time', searchable: false, render: renderDatetime },
+                    { data: 'comment', searchable: false, defaultContent: 'None' },
+                    { data: 'job_id', searchable: false, render: renderTasksButton },
                 ],
+                // options to match default jobs table
+                pageLength: 25,
+                order: [3, 'desc'],
+                layout: {
+                    topStart: null,
+                    topEnd: null,
+                    bottomStart: null,
+                    bottomEnd: null,
+                    top: [
+                        'pageLength',
+                        'info',
+                        { paging: { numbers: false } }
+                    ],
+                },
+                language: {
+                    info: "_START_ to _END_ of _TOTAL_",
+                    infoEmpty: "0 to 0 of 0",
+                    entries: { _: "jobs", 1: "job" },
+                    paginate: {
+                        first: '&laquo; First',
+                        previous: '&lsaquo; Prev',
+                        next: 'Next &rsaquo;',
+                        last: 'Last &raquo;'
+                    },
+                },
             });
         }
         // EVENT HANDLERS ------------------------------------------------

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -73,10 +73,14 @@
                 </div>
                 <!-- advanced search (uses full jobs table)-->
                 <hr class="flex-grow-1 border-secondary">
+                <div class="form-check form-switch mb-1">
+                    <input id="advanced-search-toggle"class="form-check-input" type="checkbox" role="switch" onchange="toggleAdvancedSearch(event)">
+                    <label class="form-check-label" for="advanced-search-toggle">Enable advanced search</label>
+                </div>
                 <div class="input-group input-group-sm mb-1">
                     <span class="input-group-text" style="width:35%">Search</span>
-                    <input id="advanced-search-input" type="text" class="form-control" placeholder="asset name or job id" oninput="searchFullJobsTable(event)"/>
-                    <button id="advanced-search-clear" class="btn btn-outline-secondary" type="button" title="Clear" onclick="clearAdvancedSearch(event)">
+                    <input id="advanced-search-input" type="text" class="form-control" placeholder="asset name or job id" oninput="searchFullJobsTable(event)" disabled/>
+                    <button id="advanced-search-clear" class="btn btn-outline-secondary" type="button" title="Clear" onclick="clearAdvancedSearch(event)" disabled>
                         <i class="bi bi-x-lg"></i>
                     </button>
                 </div>
@@ -115,7 +119,7 @@
             <!-- iframe to display paginated job status table -->
             <iframe id="jobs-iframe" src=""></iframe>
         </div>
-        <div id="full-jobs-table">
+        <div id="full-jobs-table" hidden>
             <table id="searchJobsTable" class="display compact table table-bordered table-sm" style="font-size: small">
                 <thead>
                     <tr>
@@ -204,10 +208,12 @@
                     tableUrls.full.searchParams.set(key, value);
                 }
             });
-            // Update job tables
-            var iframe = document.getElementById('jobs-iframe');
-            iframe.src = tableUrls.default.toString();
-            if (DataTable.isDataTable('#searchJobsTable')) {
+            // Update only the currently enabled table
+            let isDefault = !document.getElementById('advanced-search-toggle').checked;
+            if (isDefault) {
+                var iframe = document.getElementById('jobs-iframe');
+                iframe.src = tableUrls.default.toString();
+            } else if (DataTable.isDataTable('#searchJobsTable')) {
                 $('#searchJobsTable').DataTable().ajax.url(tableUrls.full.toString()).load();
             } else {
                 createFullJobsTable();
@@ -229,6 +235,17 @@
             });
         }
         // Advanced search (full table)
+        function toggleAdvancedSearch(event) {
+            let isDefault = !event.target.checked;
+            // enable/disable advanced-search-input
+            $('#advanced-search-input').prop('disabled', isDefault);
+            $('#advanced-search-clear').prop('disabled', isDefault);
+            // update appropriate table
+            $('#default-jobs-table').prop('hidden', !isDefault);
+            $('#full-jobs-table').prop('hidden', isDefault);
+            updateJobStatusTable({});
+            event.target.blur();
+        };
         function searchFullJobsTable(event) {
             event.preventDefault();
             let searchValue = event.target.value;

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.8.1/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.1.8/css/dataTables.dataTables.css" />
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
+    <script src="https://cdn.datatables.net/2.1.8/js/dataTables.js"></script>
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
     <title>{% block title %} {% endblock %} AIND Data Transfer Service Jobs</title>
     <style>
@@ -18,7 +20,7 @@
         nav {
             height: 40px;
         }
-        .content {
+        #default-jobs-table {
             width: 100%;
             height: calc(100vh - 200px);
             iframe {
@@ -89,38 +91,64 @@
                 </form>
             </div>
         </div>
-        <!-- toolbar to change jobs per page and navigate pages -->
-        <div id="jobs-toolbar" class="btn-toolbar justify-content-between mb-2" role="toolbar">
-            <div class="input-group input-group-sm">
-                <select class="form-select" onchange="updateJobStatusTableLimit(this.value);this.blur();">
-                    {% for l in [10, 25, 50, 100] %}
-                    {% if l==default_limit %}<option value="{{ l }}" selected>{{ l }}</option>
-                    {% else %}<option value="{{ l }}">{{ l }}</option>
-                    {% endif %}
-                    {% endfor %}
-                </select>
-                <span class="input-group-text">jobs per page</span>
+        <!-- job status tables -->
+        <div id="default-jobs-table">
+            <!-- toolbar to change jobs per page and navigate pages -->
+            <div id="jobs-toolbar" class="btn-toolbar justify-content-between mb-2" role="toolbar">
+                <div class="input-group input-group-sm">
+                    <select class="form-select" onchange="updateJobStatusTableLimit(this.value);this.blur();">
+                        {% for l in [10, 25, 50, 100] %}
+                        {% if l==default_limit %}<option value="{{ l }}" selected>{{ l }}</option>
+                        {% else %}<option value="{{ l }}">{{ l }}</option>
+                        {% endif %}
+                        {% endfor %}
+                    </select>
+                    <span class="input-group-text">jobs per page</span>
+                </div>
+                <div class="btn-group btn-group-sm" role="group">
+                    <!-- display current jobs range e.g, "1 to 10 of 100" -->
+                    <span id="jobs-iframe-showing" class="btn" style="cursor:default;"></span>
+                </div>
+                <div class="btn-group pagination pagination-sm" role="group">
+                    <button id="jobs-page-btn-first" type="button" class="btn page-link"
+                        onclick="updateJobStatusTablePage(PaginateTo.FIRST);this.blur();">&laquo; First</button>
+                    <button id="jobs-page-btn-prev" type="button" class="btn page-link"
+                        onclick="updateJobStatusTablePage(PaginateTo.PREV);this.blur();"
+                        >&lsaquo; Prev</button>
+                    <button id="jobs-page-btn-next" type="button" class="btn page-link"
+                        onclick="updateJobStatusTablePage(PaginateTo.NEXT);this.blur();">Next &rsaquo;</button>
+                    <button id="jobs-page-btn-last" type="button" class="btn page-link"
+                        onclick="updateJobStatusTablePage(PaginateTo.LAST);this.blur();">Last &raquo;</button>
+                </div>
             </div>
-            <div class="btn-group btn-group-sm" role="group">
-                <!-- display current jobs range e.g, "1 to 10 of 100" -->
-                <span id="jobs-iframe-showing" class="btn" style="cursor:default;"></span>
-            </div>
-            <div class="btn-group pagination pagination-sm" role="group">
-                <button id="jobs-page-btn-first" type="button" class="btn page-link"
-                    onclick="updateJobStatusTablePage(PaginateTo.FIRST);this.blur();">&laquo; First</button>
-                <button id="jobs-page-btn-prev" type="button" class="btn page-link"
-                    onclick="updateJobStatusTablePage(PaginateTo.PREV);this.blur();"
-                    >&lsaquo; Prev</button>
-                <button id="jobs-page-btn-next" type="button" class="btn page-link"
-                    onclick="updateJobStatusTablePage(PaginateTo.NEXT);this.blur();">Next &rsaquo;</button>
-                <button id="jobs-page-btn-last" type="button" class="btn page-link"
-                    onclick="updateJobStatusTablePage(PaginateTo.LAST);this.blur();">Last &raquo;</button>
-            </div>
+            <!-- iframe to display paginated job status table -->
+            <iframe id="jobs-iframe" src=""></iframe>
         </div>
-        <!-- iframe to display paginated job status table -->
-        <iframe id="jobs-iframe" src=""></iframe>
+        <div id="full-jobs-table">
+            <table id="searchJobsTable" class="display compact table table-bordered table-sm" style="font-size: small">
+                <thead>
+                    <tr>
+                        <th>Asset Name</th>
+                        <th>Job ID</th>
+                        <th>Status</th>
+                        <th>Submit Time</th>
+                        <th>Start Time</th>
+                        <th>End Time</th>
+                        <th>Comment</th>
+                        <th>Tasks</th>
+                    </tr>
+                </thead>
+            </table>
+        </div>
     </div>
     <script>
+        // User can filter for jobs by status and submit time, and view results in 2 ways:
+        // 1. Default table: Loads 1 page of jobs at a time using Jinja template.
+        // 2. Full Jobs Table: Loads all jobs using DataTables library. Enables searching across all jobs.
+        let tableUrls = {
+            default: new URL("{{ url_for('job_status_table') }}"),
+            full: new URL("{{ url_for('get_job_status_list') }}" + "?get_all_jobs=true"),
+        };  
         const PaginateTo = {
             NEXT: 'next',
             PREV: 'prev',
@@ -154,21 +182,50 @@
                 execution_date_gte: twoWeeksAgo.startOf('day').toISOString(),
                 execution_date_lte: today.endOf('day').toISOString(),
             };
-            updateJobStatusTable(initialParams, false, true);
+            updateJobStatusTable(initialParams);
         });
+        // FULL JOBS TABLE -----------------------------------------------
+        function createFullJobsTable() {
+            $('#searchJobsTable').DataTable({
+                ajax: {
+                    url: tableUrls.full,
+                    dataSrc: 'data.job_status_list'
+                },
+                processing: true,
+                columns: [
+                    { data: 'name', searchable: true },
+                    { data: 'job_id', searchable: true },
+                    { data: 'job_state', searchable: false },
+                    { data: 'submit_time', searchable: false },
+                    { data: 'start_time', searchable: false },
+                    { data: 'end_time', searchable: false },
+                    { data: 'comment', searchable: false },
+                    { data: 'job_id', searchable: false },
+                ],
+            });
+        }
         // EVENT HANDLERS ------------------------------------------------
-        function updateJobStatusTable(newParams, isSearchJobId=false, isInitial=false) {
-            var iframe = document.getElementById('jobs-iframe');
-            var currentUrl = isInitial ?  new URL("{{ url_for('job_status_table') }}") : new URL(iframe.src);
+        function updateJobStatusTable(newParams, isSearchJobId=false) {
             Object.entries(newParams).forEach(([key, value]) => {
-                currentUrl.searchParams.set(key, value);
+                tableUrls.default.searchParams.set(key, value);
+                // Ignore paginate changes for full jobs table
+                if (key !== 'limit' && key !== 'offset') {
+                    tableUrls.full.searchParams.set(key, value);
+                }
             });
             // reset job_id filter
             if (!isSearchJobId) {
                 document.getElementById('job-id-input').value = '';
-                currentUrl.searchParams.delete('dag_run_id');
+                tableUrls.default.searchParams.delete('dag_run_id');
             }
-            iframe.src = currentUrl.toString();
+            // Update job tables
+            var iframe = document.getElementById('jobs-iframe');
+            iframe.src = tableUrls.default.toString();
+            if (DataTable.isDataTable('#searchJobsTable')) {
+                $('#searchJobsTable').DataTable().ajax.url(tableUrls.full.toString()).load();
+            } else {
+                createFullJobsTable();
+            }
         }
         // Filters
         function filterJobsByStatus(newStatus) {
@@ -197,15 +254,14 @@
             // clear job id filter and reset to first page
             updateJobStatusTable({ offset: 0 }, false);
         }
-        // Pagination
+        // Pagination (default table)
         function updateJobStatusTableLimit(newLimit) {
             updateJobStatusTable({limit: newLimit});
         }
         function updateJobStatusTablePage(paginateTo) {
             var iframe = document.getElementById('jobs-iframe');
-            var currentUrl = new URL(iframe.src);
-            var offset = parseInt(currentUrl.searchParams.get('offset'));
-            var limit = parseInt(currentUrl.searchParams.get('limit'));
+            var offset = parseInt(tableUrls.default.searchParams.get('offset'));
+            var limit = parseInt(tableUrls.default.searchParams.get('limit'));
             switch (paginateTo) {
                 case PaginateTo.NEXT:
                     offset += limit;

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -706,6 +706,7 @@ class TestServer(unittest.TestCase):
         """Tests get_job_status_list when get_all_jobs is True."""
 
         def mock_airflow_dags(url, params):
+            """Mocks the response from airflow."""
             limit = int(params.get("limit"))
             mock_dag_runs_response = Response()
             mock_dag_runs_response.status_code = 200

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1135,6 +1135,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Jobs Submitted:", response.text)
 
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("httpx.AsyncClient.get")
     def test_jobs_table_success(self, mock_get: MagicMock):
         """Tests that job status table renders as expected."""


### PR DESCRIPTION
closes #180

This PR enables users to search all jobs by asset name or job id.
- GET `/api/v1/get_job_status_list?get_all_jobs=true`:  get all jobs from airflow that match default or provided status and submit time range
    - Uses httpx aysnc client to send requests concurrently to airflow. Takes ~3s to fetch ~1000 jobs.
- Add "Advanced Search" options in job status page
    - Default table is still original table that gets 1 page of jobs at a time
    - If the user enables the advanced search toggle, the full jobs table is shown instead.
        - Full jobs table uses JS [Datatables library](https://datatables.net/) to render and search full jobs list, fully in client-side.
        - Full jobs table has same UI rendering (status colors, task buttons, etc), pagination, etc.
    - User can search by asset name or job id in the search bar. Results are filtered as user types.


![image](https://github.com/user-attachments/assets/ac245754-7e73-4700-b25a-3d4615d3eb70)

![image](https://github.com/user-attachments/assets/0a133637-e691-4b76-a6fd-d57231e93111)
