### PR TITLE
feat: job types parameters

### DIFF
--- a/docs/source/Contributing.rst
+++ b/docs/source/Contributing.rst
@@ -68,6 +68,8 @@ To run uvicorn locally:
    export AIND_AIRFLOW_SERVICE_PASSWORD='*****'
    export AIND_AIRFLOW_SERVICE_USER='user'
    export ENV_NAME='local'
+   export AWS_DEFAULT_REGION='us-west-2'
+   export AIND_AIRFLOW_PARAM_PREFIX='/aind/dev/airflow/variables/job_types'
    uvicorn aind_data_transfer_service.server:app --host 0.0.0.0 --port 5000 --reload
 
 You can now access aind-data-transfer-service at

--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -514,6 +514,15 @@ Viewing the status of submitted jobs
 The status of submitted jobs can be viewed at:
 http://aind-data-transfer-service/jobs
 
+Viewing job parameters based on job type
+--------------------------------------------
+
+We store pre-compiled job configurations in AWS Parameter Store based on `job_type`.
+Available job types and their configurations can be viewed at:
+http://aind-data-transfer-service/job_params
+
+To request a new job type, please reach out to Scientific Computing.
+
 Reporting bugs or making feature requests
 -----------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     'boto3',
+    'boto3-stubs[ssm]',
     'pydantic>=2.7,<2.9',
     'pydantic-settings>=2.0',
     'aind-data-schema>=1.0.0,<2.0',

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -229,3 +229,10 @@ class JobParametersConfigs(BaseModel):
                 "param_name": param_name,
             }
         return None
+
+    @staticmethod
+    def get_parameter_name(job_type: str, task_id: str) -> str:
+        """Create the parameter name from job_type and task_id"""
+        return (
+            f"{JobParametersConfigs._PARAM_PREFIX}/{job_type}/tasks/{task_id}"
+        )

--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -209,12 +209,7 @@ class JobTasks(BaseModel):
 class JobParamConfigs(BaseModel):
     """Configs for job_type parameters in AWS Parameter Store"""
 
-    _AWS_ENV_NAME: ClassVar[str] = (
-        "prod" if os.getenv("ENV_NAME") == "prod" else "dev"
-    )
-    _PARAM_PREFIX: ClassVar[str] = (
-        f"/aind/{_AWS_ENV_NAME}/airflow/variables/job_types"
-    )
+    _PARAM_PREFIX: ClassVar[str] = os.getenv("AIND_AIRFLOW_PARAM_PREFIX", "")
     _PARAM_REGEX: ClassVar[Pattern] = re.compile(
         f"{_PARAM_PREFIX}/(?P<job_type>[^/]+)/tasks/(?P<task_id>[^/]+)"
     )

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -779,6 +779,21 @@ async def jobs(request: Request):
     )
 
 
+async def job_params(request: Request):
+    """Get Job Parameters page"""
+    return templates.TemplateResponse(
+        name="job_params.html",
+        context=(
+            {
+                "request": request,
+                "project_names_url": os.getenv(
+                    "AIND_METADATA_SERVICE_PROJECT_NAMES_URL"
+                ),
+            }
+        ),
+    )
+
+
 async def download_job_template(_: Request):
     """Get job template as xlsx filestream for download"""
 
@@ -908,6 +923,7 @@ routes = [
     Route("/job_status_table", endpoint=job_status_table, methods=["GET"]),
     Route("/job_tasks_table", endpoint=job_tasks_table, methods=["GET"]),
     Route("/task_logs", endpoint=task_logs, methods=["GET"]),
+    Route("/job_params", endpoint=job_params, methods=["GET"]),
     Route(
         "/api/job_upload_template",
         endpoint=download_job_template,

--- a/src/aind_data_transfer_service/templates/index.html
+++ b/src/aind_data_transfer_service/templates/index.html
@@ -46,6 +46,7 @@
     <nav>
         <a href="/">Submit Jobs</a> |
         <a href="/jobs">Job Status</a> |
+        <a href="/job_params">Job Parameters</a> |
         <a title="Download job template as .xslx" href= "/api/job_upload_template" download>Job Submit Template</a> |
         <a title="List of project names" href= "{{ project_names_url }}" target="_blank" >Project Names</a> |
         <a title="For more information click here" href="https://aind-data-transfer-service.readthedocs.io"  target="_blank" >Help</a>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -46,6 +46,7 @@
                         <th>Job Type</th>
                         <th>Task ID</th>
                         <th>Parameter Name</th>
+                        <th>Last Modified</th>
                     </tr>
                 </thead>
             </table>
@@ -106,19 +107,8 @@
                 columns: [
                     { data: 'job_type', searchPanes: {show: true} },
                     { data: 'task_id', searchPanes: {show: true} },
-                    {
-                        data: 'param_name',
-                        render: function (data, type, row) {
-                            return `<button type="button" class="btn btn-link btn-sm" 
-                                        data-bs-toggle="modal" 
-                                        data-bs-target="#param-modal" 
-                                        data-bs-param-name=${data} 
-                                        data-bs-job-type=${row.job_type} 
-                                        data-bs-task-id=${row.task_id}
-                                    >${data}
-                                    </button>`;
-                        },
-                    }
+                    { data: 'name', render: renderParameterButton },
+                    { data: 'last_modified', render: renderDatetime },
                 ],
                 order: [0, 'asc'],
                 searchPanes: {
@@ -150,6 +140,24 @@
                     },
                 },
             });
+        }
+        function renderDatetime(data, type, row) {
+            return (type === 'display') ? moment.utc(data).local().format('YYYY-MM-DD h:mm:ss a') : data;
+        }
+        function renderParameterButton(data, type, row) {
+            if (type == 'display') {
+                return (
+                    `<button type="button" class="btn btn-link btn-sm" 
+                        data-bs-toggle="modal" 
+                        data-bs-target="#param-modal" 
+                        data-bs-param-name=${data} 
+                        data-bs-job-type=${row.job_type} 
+                        data-bs-task-id=${row.task_id}
+                    >${data}
+                    </button>`
+                );
+            }
+            return data;
         }
     </script>
     </body>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -46,11 +46,51 @@
                     </tr>
                 </thead>
             </table>
+            <!-- modal for displaying param value as json -->
+            <div class="modal fade" id="param-modal" tabindex="-1" aria-labelledby="param-modal-label" aria-hidden="true">
+                <div class="modal-dialog modal-xl">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="param-modal-label"></h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <pre id="param-modal-content" class="bg-light p-1 border rounded"></pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script>
         $(document).ready(function() {
             createJobParamsTable();
+            // Event listeners for param value modal
+            $('#param-modal').on('show.bs.modal', function(event) {
+                var button = $(event.relatedTarget);
+                var paramName = button.data('bs-param-name');
+                var jobType = button.data('bs-job-type');
+                var taskId = button.data('bs-task-id');
+                // update the modal label and contents
+                var modal = $(this);
+                modal.find('#param-modal-label').text(paramName);
+                var get_parameter_url = `/api/v1/parameters/job_types/${jobType}/tasks/${taskId}`;
+                $.ajax({
+                    url: get_parameter_url,
+                    type: 'GET',
+                    success: function(response) {
+                        jsonStr = JSON.stringify(response.data, null, 3);
+                        modal.find('#param-modal-content').text(jsonStr);
+                    },
+                    error: function(xhr, status, error) {
+                        modal.find('#param-modal-content').text(error);
+                    }
+                });
+            });
+            $('#param-modal').on('hidden.bs.modal', function() {
+                $(this).find('#param-modal-label').text('');
+                $(this).find('#param-modal-content').text('');
+            });
         });
         // Create DataTable for job params table
         function createJobParamsTable() {
@@ -63,7 +103,20 @@
                 columns: [
                     { data: 'job_type', searchable: true },
                     { data: 'task_id', searchable: true },
-                    { data: 'param_name', searchable: false }
+                    {
+                        data: 'param_name',
+                        render: function (data, type, row) {
+                            return `<button type="button" class="btn btn-link btn-sm" 
+                                        data-bs-toggle="modal" 
+                                        data-bs-target="#param-modal" 
+                                        data-bs-param-name=${data} 
+                                        data-bs-job-type=${row.job_type} 
+                                        data-bs-task-id=${row.task_id}
+                                    >${data}
+                                    </button>`;
+                        },
+                        searchable: false,
+                    }
                 ],
                 order: [0, 'asc'],
                 // options to match default jobs table

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -111,9 +111,6 @@
                     { data: 'last_modified', render: renderDatetime },
                 ],
                 order: [0, 'asc'],
-                searchPanes: {
-                    preSelect: [ { rows: ['default'], column: 0 } ],
-                },
                 // options to match default jobs table
                 pageLength: 25,
                 layout: {

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.8.1/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.1.8/css/dataTables.dataTables.css" />
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>
+    <script src="https://cdn.datatables.net/2.1.8/js/dataTables.js"></script>
+    <title>{% block title %} {% endblock %} AIND Data Transfer Service Job Parameters</title>
+    <style>
+        body {
+            margin: 20px;
+            font-family: arial, sans-serif;
+        }
+        nav {
+            height: 40px;
+        }
+        .modal-body {
+            max-height: calc(100vh - 200px);
+            overflow: auto;
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <a href="/">Submit Jobs</a> |
+        <a href="/jobs">Job Status</a> |
+        <a href="/job_params">Job Parameters</a> |
+        <a title="Download job template as .xslx" href= "/api/job_upload_template" download>Job Submit Template</a> |
+        <a title="List of project names" href= "{{ project_names_url }}" target="_blank" >Project Names</a> |
+        <a title="For more information click here" href="https://aind-data-transfer-service.readthedocs.io"  target="_blank" >Help</a>
+    </nav>
+    <div class="content">
+        <h4 class="mb-2">Job Parameters</h4>
+        <!-- job params table -->
+        <div>
+            <table id="job-params-table" class="display compact table table-bordered table-sm" style="font-size: small">
+                <thead>
+                    <tr>
+                        <th>Job Type</th>
+                        <th>Task ID</th>
+                        <th>Parameter Name</th>
+                    </tr>
+                </thead>
+            </table>
+        </div>
+    </div>
+    <script>
+        $(document).ready(function() {
+            createJobParamsTable();
+        });
+        // Create DataTable for job params table
+        function createJobParamsTable() {
+            $('#job-params-table').DataTable({
+                ajax: {
+                    url: "{{ url_for('list_parameters') }}",
+                    dataSrc: 'data'
+                },
+                processing: true,
+                columns: [
+                    { data: 'job_type', searchable: true },
+                    { data: 'task_id', searchable: true },
+                    { data: 'param_name', searchable: false }
+                ],
+                order: [0, 'asc'],
+                // options to match default jobs table
+                pageLength: 25,
+                layout: {
+                    topStart: null,
+                    topEnd: null,
+                    bottomStart: null,
+                    bottomEnd: null,
+                    top1Start: "search",
+                    top: [
+                        'pageLength',
+                        'info',
+                        { paging: { numbers: false } }
+                    ],
+                },
+                language: {
+                    info: "_START_ to _END_ of _TOTAL_",
+                    infoEmpty: "0 to 0 of 0",
+                    entries: { _: "parameters", 1: "parameter" },
+                    paginate: {
+                        first: '&laquo; First',
+                        previous: '&lsaquo; Prev',
+                        next: 'Next &rsaquo;',
+                        last: 'Last &raquo;'
+                    },
+                },
+            });
+        }
+    </script>
+    </body>
+</html>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -5,10 +5,13 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.8.1/font/bootstrap-icons.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.datatables.net/2.1.8/css/dataTables.dataTables.css" />
+    <link rel="stylesheet" href="https://cdn.datatables.net/searchpanes/2.3.3/css/searchPanes.dataTables.css" />
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>
     <script src="https://cdn.datatables.net/2.1.8/js/dataTables.js"></script>
+    <script src="https://cdn.datatables.net/searchpanes/2.3.3/js/dataTables.searchPanes.js"></script>
+    <script src="https://cdn.datatables.net/select/3.0.0/js/dataTables.select.js"></script>
     <title>{% block title %} {% endblock %} AIND Data Transfer Service Job Parameters</title>
     <style>
         body {
@@ -101,8 +104,8 @@
                 },
                 processing: true,
                 columns: [
-                    { data: 'job_type', searchable: true },
-                    { data: 'task_id', searchable: true },
+                    { data: 'job_type', searchPanes: {show: true} },
+                    { data: 'task_id', searchPanes: {show: true} },
                     {
                         data: 'param_name',
                         render: function (data, type, row) {
@@ -115,10 +118,12 @@
                                     >${data}
                                     </button>`;
                         },
-                        searchable: false,
                     }
                 ],
                 order: [0, 'asc'],
+                searchPanes: {
+                    preSelect: [ { rows: ['default'], column: 0 } ],
+                },
                 // options to match default jobs table
                 pageLength: 25,
                 layout: {
@@ -126,7 +131,7 @@
                     topEnd: null,
                     bottomStart: null,
                     bottomEnd: null,
-                    top1Start: "search",
+                    top1Start: "searchPanes",
                     top: [
                         'pageLength',
                         'info',

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -38,6 +38,7 @@
     <nav>
         <a href="/">Submit Jobs</a> |
         <a href="/jobs">Job Status</a> |
+        <a href="/job_params">Job Parameters</a> |
         <a title="Download job template as .xslx" href= "/api/job_upload_template" download>Job Submit Template</a> |
         <a title="List of project names" href= "{{ project_names_url }}" target="_blank" >Project Names</a> |
         <a title="For more information click here" href="https://aind-data-transfer-service.readthedocs.io"  target="_blank" >Help</a>

--- a/tests/resources/describe_parameters_response.json
+++ b/tests/resources/describe_parameters_response.json
@@ -1,0 +1,52 @@
+[
+   {
+      "Parameters": [
+         {
+            "Name": "/param_prefix/job1/tasks/task1",
+            "ARN": "ARN",
+            "Type": "String",
+            "LastModifiedDate": "2025-01-23 11:50:04.535000-08:00",
+            "LastModifiedUser": "LastModifiedUser",
+            "Version": 1,
+            "Tier": "Standard",
+            "Policies": [],
+            "DataType": "text"
+         },
+         {
+            "Name": "/param_prefix/job2/tasks/task2",
+            "ARN": "ARN",
+            "Type": "String",
+            "LastModifiedDate": "2025-01-23 11:50:04.605000-08:00",
+            "LastModifiedUser": "LastModifiedUser",
+            "Version": 1,
+            "Tier": "Standard",
+            "Policies": [],
+            "DataType": "text"
+         },
+         {
+            "Name": "/param_prefix/unexpected_param",
+            "ARN": "ARN",
+            "Type": "String",
+            "LastModifiedDate": "2025-01-23 11:50:04.605000-08:00",
+            "LastModifiedUser": "LastModifiedUser",
+            "Version": 1,
+            "Tier": "Standard",
+            "Policies": [],
+            "DataType": "text"
+         }
+      ],
+      "ResponseMetadata": {
+         "RequestId": "bd913f6f-d4e1-4043-b5e8-f2e9a4ea45fc",
+         "HTTPStatusCode": 200,
+         "HTTPHeaders": {
+            "server": "Server",
+            "date": "Tue, 28 Jan 2025 00:21:13 GMT",
+            "content-type": "application/x-amz-json-1.1",
+            "content-length": "818",
+            "connection": "keep-alive",
+            "x-amzn-requestid": "bd913f6f-d4e1-4043-b5e8-f2e9a4ea45fc"
+         },
+         "RetryAttempts": 0
+      }
+   }
+]

--- a/tests/resources/get_parameter_response.json
+++ b/tests/resources/get_parameter_response.json
@@ -1,0 +1,24 @@
+{
+   "Parameter": {
+      "Name": "/param_prefix/ecephys/tasks/task1",
+      "Type": "String",
+      "Value": "{\"foo\": \"bar\"}",
+      "Version": 1,
+      "LastModifiedDate": "2025-01-23 11:50:04.535000-08:00",
+      "ARN": "ARN",
+      "DataType": "text"
+   },
+   "ResponseMetadata": {
+      "RequestId": "e87ed289-0460-4f08-aef2-20d836bb5beb",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+         "server": "Server",
+         "date": "Tue, 28 Jan 2025 02:08:07 GMT",
+         "content-type": "application/x-amz-json-1.1",
+         "content-length": "630",
+         "connection": "keep-alive",
+         "x-amzn-requestid": "e87ed289-0460-4f08-aef2-20d836bb5beb"
+      },
+      "RetryAttempts": 0
+   }
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,6 +22,7 @@ from aind_data_transfer_models.core import (
     V0036JobProperties,
 )
 from aind_data_transfer_models.trigger import TriggerConfigModel, ValidJobType
+from botocore.exceptions import ClientError
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
@@ -57,6 +58,12 @@ GET_DAG_RUN_RESPONSE = (
 LIST_TASK_INSTANCES_RESPONSE = (
     TEST_DIRECTORY / "resources" / "airflow_task_instances_response.json"
 )
+DESCRIBE_PARAMETERS_RESPONSE = (
+    TEST_DIRECTORY / "resources" / "describe_parameters_response.json"
+)
+GET_PARAMETER_RESPONSE = (
+    TEST_DIRECTORY / "resources" / "get_parameter_response.json"
+)
 
 
 class TestServer(unittest.TestCase):
@@ -83,6 +90,7 @@ class TestServer(unittest.TestCase):
         "AIND_AIRFLOW_SERVICE_JOBS_URL": "airflow_jobs_url",
         "AIND_AIRFLOW_SERVICE_USER": "airflow_user",
         "AIND_AIRFLOW_SERVICE_PASSWORD": "airflow_password",
+        "AIND_AIRFLOW_PARAM_PREFIX": "/param_prefix",
     }
 
     with open(SAMPLE_CSV, "r") as file:
@@ -99,6 +107,12 @@ class TestServer(unittest.TestCase):
 
     with open(LIST_TASK_INSTANCES_RESPONSE) as f:
         list_task_instances_response = json.load(f)
+
+    with open(DESCRIBE_PARAMETERS_RESPONSE) as f:
+        describe_parameters_response = json.load(f)
+
+    with open(GET_PARAMETER_RESPONSE) as f:
+        get_parameter_response = json.load(f)
 
     expected_job_configs = deepcopy(TestJobConfigs.expected_job_configs)
     for config in expected_job_configs:
@@ -1123,6 +1137,122 @@ class TestServer(unittest.TestCase):
         )
         mock_log_error.assert_called_once()
 
+    @patch("logging.Logger.info")
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    @patch("boto3.client")
+    def test_list_parameters(
+        self,
+        mock_ssm_client,
+        mock_log_info: MagicMock,
+    ):
+        """Tests list_parameters gets parameter info from aws param store."""
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = (
+            self.describe_parameters_response
+        )
+        mock_ssm_client.return_value.get_paginator.return_value = (
+            mock_paginator
+        )
+        expected_params_list = [
+            {
+                "job_type": "job1",
+                "last_modified": "2025-01-23T11:50:04.535000-08:00",
+                "name": "/param_prefix/job1/tasks/task1",
+                "task_id": "task1",
+            },
+            {
+                "job_type": "job2",
+                "last_modified": "2025-01-23T11:50:04.605000-08:00",
+                "name": "/param_prefix/job2/tasks/task2",
+                "task_id": "task2",
+            },
+        ]
+        with TestClient(app) as client:
+            response = client.get("/api/v1/parameters")
+        mock_ssm_client.assert_called_once_with("ssm")
+        mock_ssm_client.return_value.get_paginator.assert_called_once_with(
+            "describe_parameters"
+        )
+        mock_paginator.paginate.assert_called_once_with(
+            ParameterFilters=[
+                {
+                    "Key": "Path",
+                    "Option": "Recursive",
+                    "Values": ["/param_prefix"],
+                }
+            ]
+        )
+        response_content = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response_content,
+            {
+                "message": "Retrieved job parameters",
+                "data": expected_params_list,
+            },
+        )
+        # params that do not match expected format are ignored
+        mock_log_info.assert_any_call(
+            "Ignoring /param_prefix/unexpected_param"
+        )
+
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    @patch("boto3.client")
+    def test_get_parameter(
+        self,
+        mock_ssm_client,
+    ):
+        """Tests get_parameter retrieves values from aws param store."""
+        mock_ssm_client.return_value.get_parameter.return_value = (
+            self.get_parameter_response
+        )
+        expected_param_name = "/param_prefix/ecephys/tasks/task1"
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/v1/parameters/job_types/ecephys/tasks/task1"
+            )
+        mock_ssm_client.assert_called_once_with("ssm")
+        mock_ssm_client.return_value.get_parameter.assert_called_once_with(
+            Name=expected_param_name, WithDecryption=True
+        )
+        response_content = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response_content,
+            {
+                "message": f"Retrieved parameter for {expected_param_name}",
+                "data": {"foo": "bar"},
+            },
+        )
+
+    @patch("logging.Logger.exception")
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    @patch("boto3.client")
+    def test_get_parameter_error(
+        self,
+        mock_ssm_client,
+        mock_log_error: MagicMock,
+    ):
+        """Tests get_parameter when there is a client error."""
+        mock_ssm_client.return_value.get_parameter.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ParameterNotFound",
+                    "Message": "Parameter not found",
+                }
+            },
+            "GetParameter",
+        )
+        with TestClient(app) as client:
+            response = client.get("/api/v1/parameters/job_types/foo/tasks/bar")
+        response_content = response.json()
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response_content["message"],
+            "Error retrieving parameter /param_prefix/foo/tasks/bar",
+        )
+        mock_log_error.assert_called_once()
+
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     def test_index(self):
         """Tests that form renders at startup as expected."""
@@ -1282,6 +1412,14 @@ class TestServer(unittest.TestCase):
             list(response.headers.items()),
         )
         self.assertEqual(200, response.status_code)
+
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    def test_job_params(self):
+        """Tests that job params page renders at startup as expected."""
+        with TestClient(app) as client:
+            response = client.get("/job_params")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Job Parameters", response.text)
 
     @patch("aind_data_transfer_service.server.JobUploadTemplate")
     @patch("logging.Logger.exception")


### PR DESCRIPTION
closes #202 

This PR adds apis to list and download parameters from AWS param store, and a new Job Parameters page to display parameters:

AWS parameters are expected to be at `/aind/{env}/airflow/variables/job_types/{job_type}/tasks/{task_id}`

**Api:**
- [GET] `/api/v1/parameters`: uses boto3 describe_parameters to list params
```json
{
  "message": "Retrieved job parameters",
  "data": [
    {
      "name": "/aind/dev/airflow/variables/job_types/ecephys/tasks/expand_pipelines",
      "last_modified": "2025-01-23T11:50:04.535000-08:00",
      "job_type": "ecephys",
      "task_id": "expand_pipelines"
    },
    {
      "name": "/aind/dev/airflow/variables/job_types/ecephys_opto/tasks/expand_pipelines",
      "last_modified": "2025-01-23T11:50:04.605000-08:00",
      "job_type": "ecephys_opto",
      "task_id": "expand_pipelines"
    },
    ...
```
- [GET] `/api/v1/parameters/job_types/{job_type:str}/tasks/{task_id:str}`: Retrieves param value given the job_type and task_id

**UI: Job Parameters page at `/job_params`:**
- User can filter by job type or task id
- Clicking on the parameter name shows popup of parameter value

![image](https://github.com/user-attachments/assets/c8f95971-5a03-423b-8267-34ba041775f7)

![image](https://github.com/user-attachments/assets/05ca133e-0ea2-4d6b-b327-599a2a0c4f4e)
