### PR TITLE
Support datetimes in ISO 8601 format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 WORKDIR /app
 ADD src ./src
 ADD pyproject.toml .

--- a/src/aind_data_transfer_service/configs/job_configs.py
+++ b/src/aind_data_transfer_service/configs/job_configs.py
@@ -122,9 +122,6 @@ class BasicUploadJobConfigs(BaseSettings):
         for a in Platform.abbreviation_map.keys()
     }
     _MODALITY_ENTRY_PATTERN: ClassVar = re.compile(r"^modality(\d*)$")
-    _DATETIME_PATTERN1: ClassVar = re.compile(
-        r"^\d{4}-\d{2}-\d{2}[ |T]\d{2}:\d{2}:\d{2}$"
-    )
     _DATETIME_PATTERN2: ClassVar = re.compile(
         r"^\d{1,2}/\d{1,2}/\d{4} \d{1,2}:\d{2}:\d{2} [APap][Mm]$"
     )
@@ -258,17 +255,15 @@ class BasicUploadJobConfigs(BaseSettings):
         """Parses datetime string to %YYYY-%MM-%DD HH:mm:ss"""
         is_str = isinstance(datetime_val, str)
         if is_str and re.match(
-            BasicUploadJobConfigs._DATETIME_PATTERN1, datetime_val
-        ):
-            return datetime.fromisoformat(datetime_val)
-        elif is_str and re.match(
             BasicUploadJobConfigs._DATETIME_PATTERN2, datetime_val
         ):
             return datetime.strptime(datetime_val, "%m/%d/%Y %I:%M:%S %p")
         elif is_str:
+            return datetime.fromisoformat(datetime_val)
+        elif is_str:
             raise ValueError(
                 "Incorrect datetime format, should be"
-                " YYYY-MM-DD HH:mm:ss or MM/DD/YYYY I:MM:SS P"
+                " ISO format (YYYY-MM-DD HH:mm:ss) or MM/DD/YYYY I:MM:SS P"
             )
         else:
             return datetime_val

--- a/src/aind_data_transfer_service/configs/job_configs.py
+++ b/src/aind_data_transfer_service/configs/job_configs.py
@@ -254,17 +254,21 @@ class BasicUploadJobConfigs(BaseSettings):
     def _parse_datetime(cls, datetime_val: Any) -> datetime:
         """Parses datetime string to %YYYY-%MM-%DD HH:mm:ss"""
         is_str = isinstance(datetime_val, str)
+        validation_error = ValueError(
+                "Incorrect datetime format, should be"
+                " ISO format (YYYY-MM-DD HH:mm:ss) or MM/DD/YYYY I:MM:SS P"
+            )
         if is_str and re.match(
             BasicUploadJobConfigs._DATETIME_PATTERN2, datetime_val
         ):
             return datetime.strptime(datetime_val, "%m/%d/%Y %I:%M:%S %p")
         elif is_str:
-            return datetime.fromisoformat(datetime_val)
+            try:
+                return datetime.fromisoformat(datetime_val)
+            except ValueError:
+                raise validation_error
         elif is_str:
-            raise ValueError(
-                "Incorrect datetime format, should be"
-                " ISO format (YYYY-MM-DD HH:mm:ss) or MM/DD/YYYY I:MM:SS P"
-            )
+            raise validation_error
         else:
             return datetime_val
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -165,7 +165,7 @@ class TestJobConfigs(unittest.TestCase):
 
         self.assertTrue(
             (
-                "Incorrect datetime format, should be YYYY-MM-DD HH:mm:ss "
+                "Incorrect datetime format, should be ISO format (YYYY-MM-DD HH:mm:ss) "
                 "or MM/DD/YYYY I:MM:SS P"
             )
             in repr(e1.exception)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -165,8 +165,8 @@ class TestJobConfigs(unittest.TestCase):
 
         self.assertTrue(
             (
-                "Incorrect datetime format, should be ISO format (YYYY-MM-DD HH:mm:ss) "
-                "or MM/DD/YYYY I:MM:SS P"
+                "Incorrect datetime format, should be ISO format "
+                "(YYYY-MM-DD HH:mm:ss) or MM/DD/YYYY I:MM:SS P"
             )
             in repr(e1.exception)
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1942,7 +1942,6 @@ class TestServer(unittest.TestCase):
                 json=post_request_content,
             )
             response_json = response.json()
-        print(response.text)
         self.assertEqual(200, response.status_code)
         self.assertEqual("Valid model", response_json["message"])
         self.assertEqual(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1917,7 +1917,7 @@ class TestServer(unittest.TestCase):
 
         s3_bucket = "private"
         subject_id = "690165"
-        acq_datetime = datetime(2024, 2, 19, 11, 25, 17)
+        acq_datetime = datetime(2024, 2, 19, 11, 25, 17, tzinfo=timezone.utc)
         platform = Platform.ECEPHYS
 
         ephys_config = ModalityConfigs(
@@ -1942,6 +1942,7 @@ class TestServer(unittest.TestCase):
                 json=post_request_content,
             )
             response_json = response.json()
+        print(response.text)
         self.assertEqual(200, response.status_code)
         self.assertEqual("Valid model", response_json["message"])
         self.assertEqual(


### PR DESCRIPTION
We discovered that python <3.11 cannot handle iso datetimes with a 'Z' per ISO 8601. However, simply upgrading to 3.11 doesn't fix it, as the BasicUploadJobConfigs._parse_datetime first compares datetime strings to an incomplete iso regex. 

I've updated the _parse_datetime logic to remove the regex and just let datetime try to parse iso. BUT, since data_transfer_service v1 still pulls models from aind-data-transfer-models, we'd need to make the change there.

Assigning to Yosef at Jon's instruction

https://github.com/AllenNeuralDynamics/aind-data-transfer-service/issues/224