### PR TITLE
feat: v2 endpoints

### DIFF
--- a/src/aind_data_transfer_service/models.py
+++ b/src/aind_data_transfer_service/models.py
@@ -210,15 +210,12 @@ class JobParamInfo(BaseModel):
 
     name: Optional[str]
     last_modified: Optional[datetime]
-    job_type: Optional[str]
-    task_id: Optional[str]
+    job_type: str
+    task_id: str
 
     @classmethod
     def from_aws_describe_parameter(
-        cls,
-        parameter: ParameterMetadataTypeDef,
-        job_type: Optional[str],
-        task_id: Optional[str],
+        cls, parameter: ParameterMetadataTypeDef, job_type: str, task_id: str
     ):
         """Map the parameter to the model"""
         return cls(
@@ -229,17 +226,28 @@ class JobParamInfo(BaseModel):
         )
 
     @staticmethod
-    def get_parameter_regex() -> str:
-        """Create the regex pattern to match the parameter name"""
-        return (
-            f"{os.getenv('AIND_AIRFLOW_PARAM_PREFIX')}"
-            f"/(?P<job_type>[^/]+)/tasks/(?P<task_id>[^/]+)"
-        )
+    def get_parameter_prefix(version: Optional[str] = None) -> str:
+        """Get the prefix for job_type parameters"""
+        prefix = os.getenv("AIND_AIRFLOW_PARAM_PREFIX")
+        if version is None:
+            return prefix
+        return f"{prefix}/{version}"
 
     @staticmethod
-    def get_parameter_name(job_type: str, task_id: str) -> str:
+    def get_parameter_regex(version: Optional[str] = None) -> str:
+        """Create the regex pattern to match the parameter name"""
+        prefix = os.getenv("AIND_AIRFLOW_PARAM_PREFIX")
+        regex = "(?P<job_type>[^/]+)/tasks/(?P<task_id>[^/]+)"
+        if version is None:
+            return f"{prefix}/{regex}"
+        return f"{prefix}/{version}/{regex}"
+
+    @staticmethod
+    def get_parameter_name(
+        job_type: str, task_id: str, version: Optional[str] = None
+    ) -> str:
         """Create the parameter name from job_type and task_id"""
-        return (
-            f"{os.getenv('AIND_AIRFLOW_PARAM_PREFIX')}"
-            f"/{job_type}/tasks/{task_id}"
-        )
+        prefix = os.getenv("AIND_AIRFLOW_PARAM_PREFIX")
+        if version is None:
+            return f"{prefix}/{job_type}/tasks/{task_id}"
+        return f"{prefix}/{version}/{job_type}/tasks/{task_id}"

--- a/src/aind_data_transfer_service/models/core.py
+++ b/src/aind_data_transfer_service/models/core.py
@@ -67,19 +67,19 @@ class Task(BaseSettings):
         title="Image Version",
     )
     image_environment: Optional[Dict[str, Any]] = Field(
-        default={},
+        default=None,
         description=(
             "Environment for the docker image. Must be json serializable."
         ),
         title="Image Environment",
     )
     parameters_settings: Optional[Dict[str, Any]] = Field(
-        default={},
+        default=None,
         description="Settings for the task. Must be json serializable.",
         title="Parameters Settings",
     )
     dynamic_parameters_settings: Optional[Dict[str, Any]] = Field(
-        default={},
+        default=None,
         description=(
             "Dynamic settings for the task (e.g. modality, source, chunk). "
             "Must be json serializable."

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -29,10 +29,6 @@ from aind_data_transfer_service import OPEN_DATA_BUCKET_NAME
 from aind_data_transfer_service import (
     __version__ as aind_data_transfer_service_version,
 )
-from aind_data_transfer_service.configs.core import SubmitJobRequestV2
-from aind_data_transfer_service.configs.core import (
-    validation_context as validation_context_v2,
-)
 from aind_data_transfer_service.configs.csv_handler import map_csv_row_to_job
 from aind_data_transfer_service.configs.job_configs import (
     BasicUploadJobConfigs as LegacyBasicUploadJobConfigs,
@@ -44,6 +40,10 @@ from aind_data_transfer_service.configs.job_upload_template import (
 from aind_data_transfer_service.hpc.client import HpcClient, HpcClientConfigs
 from aind_data_transfer_service.hpc.models import HpcJobSubmitSettings
 from aind_data_transfer_service.log_handler import LoggingConfigs, get_logger
+from aind_data_transfer_service.models.core import SubmitJobRequestV2
+from aind_data_transfer_service.models.core import (
+    validation_context as validation_context_v2,
+)
 from aind_data_transfer_service.models.internal import (
     AirflowDagRunsRequestParameters,
     AirflowDagRunsResponse,

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -252,8 +252,8 @@ async def validate_json_v2(request: Request):
     content = await request.json()
     try:
         context = {
-            "project_names": get_project_names(),
             "job_types": get_job_types("v2"),
+            "project_names": get_project_names(),
         }
         with validation_context_v2(context):
             validated_model = SubmitJobRequestV2.model_validate_json(
@@ -362,8 +362,8 @@ async def submit_jobs_v2(request: Request):
     content = await request.json()
     try:
         context = {
-            "project_names": get_project_names(),
             "job_types": get_job_types("v2"),
+            "project_names": get_project_names(),
         }
         with validation_context_v2(context):
             model = SubmitJobRequestV2.model_validate_json(json.dumps(content))
@@ -415,6 +415,7 @@ async def submit_jobs_v2(request: Request):
                 "data": {"responses": [], "errors": str(e.args)},
             },
         )
+
 
 async def submit_jobs(request: Request):
     """Post BasicJobConfigs raw json to hpc server to process."""

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -843,6 +843,8 @@ async def job_params(request: Request):
                 "project_names_url": os.getenv(
                     "AIND_METADATA_SERVICE_PROJECT_NAMES_URL"
                 ),
+                "versions": ["v1", "v2"],
+                "default_version": "v1",
             }
         ),
     )

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -37,7 +37,7 @@
         <a title="For more information click here" href="https://aind-data-transfer-service.readthedocs.io"  target="_blank" >Help</a>
     </nav>
     <div class="content">
-        <h4 class="mb-2">Job Parameters
+        <h4 class="mb-2">
             <!-- dropdown to switch version -->
             <div id="version-dropdown" class="btn-group mb-2">
                 <button id="version-button" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
@@ -49,6 +49,7 @@
                     {% endfor %}
                 </ul>
             </div>
+            <span>Job Parameters</span>
         </h4>
         <!-- job params table -->
         <div>
@@ -91,9 +92,9 @@
                 var modal = $(this);
                 modal.find('#param-modal-label').text(paramName);
                 var version = $('#version-button').text().trim();
-                var get_parameter_url = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
+                var getParameterUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
                 $.ajax({
-                    url: get_parameter_url,
+                    url: getParameterUrl,
                     type: 'GET',
                     success: function(response) {
                         jsonStr = JSON.stringify(response.data, null, 3);
@@ -111,8 +112,10 @@
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
                 var version = $(this).text();
-                $('#version-button').text(version);
-                $('#job-params-table').DataTable().ajax.url(`/api/${version}/parameters`).load();
+                if (version != $('#version-button').text().trim()) {
+                    $('#version-button').text(version);
+                    $('#job-params-table').DataTable().ajax.url(`/api/${version}/parameters`).load();
+                }
             });
         });
         // Create DataTable for job params table

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -37,7 +37,19 @@
         <a title="For more information click here" href="https://aind-data-transfer-service.readthedocs.io"  target="_blank" >Help</a>
     </nav>
     <div class="content">
-        <h4 class="mb-2">Job Parameters</h4>
+        <h4 class="mb-2">Job Parameters
+            <!-- dropdown to switch version -->
+            <div id="version-dropdown" class="btn-group mb-2">
+                <button id="version-button" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown">
+                    {{default_version}}
+                </button>
+                <ul class="dropdown-menu">
+                    {% for v in versions %}
+                    <button class="dropdown-item" type="button">{{ v }}</button>
+                    {% endfor %}
+                </ul>
+            </div>
+        </h4>
         <!-- job params table -->
         <div>
             <table id="job-params-table" class="display compact table table-bordered table-sm" style="font-size: small">
@@ -78,7 +90,8 @@
                 // update the modal label and contents
                 var modal = $(this);
                 modal.find('#param-modal-label').text(paramName);
-                var get_parameter_url = `/api/v1/parameters/job_types/${jobType}/tasks/${taskId}`;
+                var version = $('#version-button').text().trim();
+                var get_parameter_url = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
                 $.ajax({
                     url: get_parameter_url,
                     type: 'GET',
@@ -95,12 +108,18 @@
                 $(this).find('#param-modal-label').text('');
                 $(this).find('#param-modal-content').text('');
             });
+            // Event listener for version dropdown
+            $('#version-dropdown .dropdown-item').on('click', function() {
+                var version = $(this).text();
+                $('#version-button').text(version);
+                $('#job-params-table').DataTable().ajax.url(`/api/${version}/parameters`).load();
+            });
         });
         // Create DataTable for job params table
         function createJobParamsTable() {
             $('#job-params-table').DataTable({
                 ajax: {
-                    url: "{{ url_for('list_parameters') }}",
+                    url: "/api/{{default_version}}/parameters",
                     dataSrc: 'data'
                 },
                 processing: true,
@@ -111,6 +130,10 @@
                     { data: 'last_modified', render: renderDatetime },
                 ],
                 order: [0, 'asc'],
+                // preselect "default" job_type
+                searchPanes: {
+                    preSelect: [ { rows: ['default'], column: 0 } ],
+                },
                 // options to match default jobs table
                 pageLength: 25,
                 layout: {

--- a/tests/resources/describe_parameters_response.json
+++ b/tests/resources/describe_parameters_response.json
@@ -24,6 +24,17 @@
             "DataType": "text"
          },
          {
+            "Name": "/param_prefix/v2/job1/tasks/task1",
+            "ARN": "ARN",
+            "Type": "String",
+            "LastModifiedDate": "2025-01-23 11:50:04.605000-08:00",
+            "LastModifiedUser": "LastModifiedUser",
+            "Version": 1,
+            "Tier": "Standard",
+            "Policies": [],
+            "DataType": "text"
+         },
+         {
             "Name": "/param_prefix/unexpected_param",
             "ARN": "ARN",
             "Type": "String",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,9 +57,9 @@ class TestTask(unittest.TestCase):
             "skip_task": True,
             "image": None,
             "image_version": None,
-            "image_environment": {},
-            "parameters_settings": {},
-            "dynamic_parameters_settings": {},
+            "image_environment": None,
+            "parameters_settings": None,
+            "dynamic_parameters_settings": None,
         }
         task = Task(skip_task=True)
         self.assertDictEqual(
@@ -98,7 +98,9 @@ class TestUploadJobConfigsV2(unittest.TestCase):
             tasks={
                 "make_modality_list": Task(
                     dynamic_parameters_settings={
-                        "modality": Modality.BEHAVIOR_VIDEOS.abbreviation,
+                        "modality": Modality.BEHAVIOR_VIDEOS.model_dump(
+                            mode="json"
+                        ),
                         "source": (
                             PurePosixPath("dir") / "data_set_1"
                         ).as_posix(),
@@ -220,7 +222,9 @@ class TestUploadJobConfigsV2(unittest.TestCase):
             "make_modality_list": [
                 Task(
                     dynamic_parameters_settings={
-                        "modality": Modality.BEHAVIOR_VIDEOS.abbreviation,
+                        "modality": Modality.BEHAVIOR_VIDEOS.model_dump(
+                            mode="json"
+                        ),
                         "source": (
                             PurePosixPath("dir") / "data_set_1"
                         ).as_posix(),
@@ -229,7 +233,7 @@ class TestUploadJobConfigsV2(unittest.TestCase):
                 ),
                 Task(
                     dynamic_parameters_settings={
-                        "modality": Modality.ECEPHYS.abbreviation,
+                        "modality": Modality.ECEPHYS.model_dump(mode="json"),
                         "source": (
                             PurePosixPath("dir") / "data_set_2"
                         ).as_posix(),
@@ -262,7 +266,9 @@ class TestSubmitJobRequestV2(unittest.TestCase):
             tasks={
                 "make_modality_list": Task(
                     dynamic_parameters_settings={
-                        "modality": Modality.BEHAVIOR_VIDEOS.abbreviation,
+                        "modality": Modality.BEHAVIOR_VIDEOS.model_dump(
+                            mode="json"
+                        ),
                         "source": (
                             PurePosixPath("dir") / "data_set_1"
                         ).as_posix(),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -143,7 +143,7 @@ class TestServer(unittest.TestCase):
         ephys_source_dir = PurePosixPath("shared_drive/ephys_data/690165")
         ephys_config = Task(
             dynamic_parameters_settings={
-                "modality": Modality.ECEPHYS.abbreviation,
+                "modality": Modality.ECEPHYS.model_dump(mode="json"),
                 "source": ephys_source_dir.as_posix(),
             }
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,15 +31,15 @@ from requests import Response
 from aind_data_transfer_service import (
     __version__ as aind_data_transfer_service_version,
 )
-from aind_data_transfer_service.configs.core import (
+from aind_data_transfer_service.configs.job_upload_template import (
+    JobUploadTemplate,
+)
+from aind_data_transfer_service.models.core import (
     SubmitJobRequestV2,
     Task,
     UploadJobConfigsV2,
 )
-from aind_data_transfer_service.configs.job_upload_template import (
-    JobUploadTemplate,
-)
-from aind_data_transfer_service.models import JobParamInfo
+from aind_data_transfer_service.models.internal import JobParamInfo
 from aind_data_transfer_service.server import (
     app,
     get_job_types,


### PR DESCRIPTION
closes #217

This PR adds v2 endpoints to vaidate and submit jobs, as well as 
- POST `/api/v2/validate_json`
- POST `/api/v2/submit_jobs`
- GET `/api/v2/parameters`
- GET `/api/v2/parameters/job_types/{job_type:str}/tasks/{task_id:str}`

Additionally, the Job Parameters page was updated so that users can toggle between viewing v1 and v2. The default job_type is shown on default.
![image](https://github.com/user-attachments/assets/92f25d13-acfc-48ea-9b4b-809ea4c49719)