### PR TITLE
feat: v2 params with optional modality

### DIFF
--- a/src/aind_data_transfer_service/models/internal.py
+++ b/src/aind_data_transfer_service/models/internal.py
@@ -227,10 +227,15 @@ class JobParamInfo(BaseModel):
     last_modified: Optional[datetime]
     job_type: str
     task_id: str
+    modality: Optional[str]
 
     @classmethod
     def from_aws_describe_parameter(
-        cls, parameter: ParameterMetadataTypeDef, job_type: str, task_id: str
+        cls,
+        parameter: ParameterMetadataTypeDef,
+        job_type: str,
+        task_id: str,
+        modality: Optional[str],
     ):
         """Map the parameter to the model"""
         return cls(
@@ -238,6 +243,7 @@ class JobParamInfo(BaseModel):
             last_modified=parameter.get("LastModifiedDate"),
             job_type=job_type,
             task_id=task_id,
+            modality=modality,
         )
 
     @staticmethod
@@ -252,7 +258,10 @@ class JobParamInfo(BaseModel):
     def get_parameter_regex(version: Optional[str] = None) -> str:
         """Create the regex pattern to match the parameter name"""
         prefix = os.getenv("AIND_AIRFLOW_PARAM_PREFIX")
-        regex = "(?P<job_type>[^/]+)/tasks/(?P<task_id>[^/]+)"
+        regex = (
+            "(?P<job_type>[^/]+)/tasks/(?P<task_id>[^/]+)"
+            "(?:/(?P<modality>[^/]+))?"
+        )
         if version is None:
             return f"{prefix}/{regex}"
         return f"{prefix}/{version}/{regex}"

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -124,6 +124,7 @@ def get_parameter_infos(version: Optional[str] = None) -> List[JobParamInfo]:
                     parameter=param,
                     job_type=match.group("job_type"),
                     task_id=match.group("task_id"),
+                    modality=match.group("modality"),
                 )
                 params.append(param_info)
             else:
@@ -1069,7 +1070,7 @@ routes = [
     Route("/api/v1/get_task_logs", endpoint=get_task_logs, methods=["GET"]),
     Route("/api/v1/parameters", endpoint=list_parameters, methods=["GET"]),
     Route(
-        "/api/v1/parameters/job_types/{job_type:str}/tasks/{task_id:str}",
+        "/api/v1/parameters/job_types/{job_type:str}/tasks/{task_id:path}",
         endpoint=get_parameter,
         methods=["GET"],
     ),
@@ -1079,7 +1080,7 @@ routes = [
     Route("/api/v2/submit_jobs", endpoint=submit_jobs_v2, methods=["POST"]),
     Route("/api/v2/parameters", endpoint=list_parameters_v2, methods=["GET"]),
     Route(
-        "/api/v2/parameters/job_types/{job_type:str}/tasks/{task_id:str}",
+        "/api/v2/parameters/job_types/{job_type:str}/tasks/{task_id:path}",
         endpoint=get_parameter_v2,
         methods=["GET"],
     ),

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -58,6 +58,7 @@
                     <tr>
                         <th>Job Type</th>
                         <th>Task ID</th>
+                        <th>Modality</th>
                         <th>Parameter Name</th>
                         <th>Last Modified</th>
                     </tr>
@@ -88,11 +89,15 @@
                 var paramName = button.data('bs-param-name');
                 var jobType = button.data('bs-job-type');
                 var taskId = button.data('bs-task-id');
+                var modality = button.data('bs-modality');
                 // update the modal label and contents
                 var modal = $(this);
                 modal.find('#param-modal-label').text(paramName);
                 var version = $('#version-button').text().trim();
                 var getParameterUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
+                if (modality) {
+                    getParameterUrl += `/${modality}`;
+                }
                 $.ajax({
                     url: getParameterUrl,
                     type: 'GET',
@@ -129,6 +134,7 @@
                 columns: [
                     { data: 'job_type', searchPanes: {show: true} },
                     { data: 'task_id', searchPanes: {show: true} },
+                    { data: 'modality', searchPanes: {show: false} },
                     { data: 'name', render: renderParameterButton },
                     { data: 'last_modified', render: renderDatetime },
                 ],
@@ -176,6 +182,7 @@
                         data-bs-param-name=${data} 
                         data-bs-job-type=${row.job_type} 
                         data-bs-task-id=${row.task_id}
+                        data-bs-modality=${row.modality}
                     >${data}
                     </button>`
                 );

--- a/tests/resources/describe_parameters_response.json
+++ b/tests/resources/describe_parameters_response.json
@@ -35,6 +35,17 @@
             "DataType": "text"
          },
          {
+            "Name": "/param_prefix/v2/job1/tasks/task2/modality1",
+            "ARN": "ARN",
+            "Type": "String",
+            "LastModifiedDate": "2025-01-23 11:50:04.605000-08:00",
+            "LastModifiedUser": "LastModifiedUser",
+            "Version": 1,
+            "Tier": "Standard",
+            "Policies": [],
+            "DataType": "text"
+         },
+         {
             "Name": "/param_prefix/unexpected_param",
             "ARN": "ARN",
             "Type": "String",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -612,12 +612,17 @@ class TestServer(unittest.TestCase):
     @patch("aind_data_transfer_service.server.get_parameter_infos")
     def test_get_job_types(self, mock_get_parameter_infos: MagicMock):
         """Tests get_job_types method"""
-        tasks = [("job1", "task1"), ("job1", "task2"), ("job2", "task1")]
+        tasks = [
+            ("job1", "task1", None),
+            ("job1", "task2", None),
+            ("job2", "task1", "modality1"),
+        ]
         mock_get_parameter_infos.return_value = [
             JobParamInfo(
                 name=f"/param_prefix/v2/{t[0]}/tasks/{t[1]}",
                 job_type=t[0],
                 task_id=t[1],
+                modality=t[2],
                 last_modified=None,
             )
             for t in tasks
@@ -1277,12 +1282,14 @@ class TestServer(unittest.TestCase):
                     "last_modified": "2025-01-23T11:50:04.535000-08:00",
                     "name": "/param_prefix/job1/tasks/task1",
                     "task_id": "task1",
+                    "modality": None,
                 },
                 {
                     "job_type": "job2",
                     "last_modified": "2025-01-23T11:50:04.605000-08:00",
                     "name": "/param_prefix/job2/tasks/task2",
                     "task_id": "task2",
+                    "modality": None,
                 },
             ],
             "v2": [
@@ -1291,6 +1298,14 @@ class TestServer(unittest.TestCase):
                     "last_modified": "2025-01-23T11:50:04.605000-08:00",
                     "name": "/param_prefix/v2/job1/tasks/task1",
                     "task_id": "task1",
+                    "modality": None,
+                },
+                {
+                    "job_type": "job1",
+                    "last_modified": "2025-01-23T11:50:04.605000-08:00",
+                    "name": "/param_prefix/v2/job1/tasks/task2/modality1",
+                    "task_id": "task2",
+                    "modality": "modality1",
                 },
             ],
         }


### PR DESCRIPTION
Display expanded task params from `job_types/v2/{job_type}/tasks/{task_id}/{modality_abbreviation}`

![image](https://github.com/user-attachments/assets/6a888c4f-7c92-4a24-8eca-a522c3672d64)
