### PR TITLE
feat: prevent duplicate upload jobs

### DIFF
--- a/src/aind_data_transfer_service/models/core.py
+++ b/src/aind_data_transfer_service/models/core.py
@@ -290,9 +290,10 @@ class SubmitJobRequestV2(BaseSettings):
         # check against any jobs in the context
         current_jobs = (info.context or dict()).get("current_jobs", [])
         for job in current_jobs:
-            prefix = job["s3_prefix"]
+            prefix = job.get("s3_prefix")
             if (
-                prefix in jobs_map
+                prefix is not None
+                and prefix in jobs_map
                 and json.dumps(job, sort_keys=True) in jobs_map[prefix]
             ):
                 raise ValueError(f"Job is already running/queued for {prefix}")

--- a/src/aind_data_transfer_service/models/core.py
+++ b/src/aind_data_transfer_service/models/core.py
@@ -119,7 +119,7 @@ class UploadJobConfigsV2(BaseSettings):
 
     # noinspection PyMissingConstructor
     def __init__(self, /, **data: Any) -> None:
-        """Add context manager to init for validating project_names."""
+        """Add context manager to init for validating fields."""
         self.__pydantic_validator__.validate_python(
             data,
             self_instance=self,
@@ -226,7 +226,7 @@ class SubmitJobRequestV2(BaseSettings):
 
     # noinspection PyMissingConstructor
     def __init__(self, /, **data: Any) -> None:
-        """Add context manager to init for validating project_names."""
+        """Add context manager to init for validating upload_jobs."""
         self.__pydantic_validator__.validate_python(
             data,
             self_instance=self,
@@ -276,7 +276,7 @@ class SubmitJobRequestV2(BaseSettings):
         """Validate that there are no duplicate upload jobs. If a list of
         current jobs is provided in a context manager, jobs are also checked
         against the list."""
-        jobs_map = {}
+        jobs_map = dict()
         # check jobs with the same s3_prefix
         for job in self.upload_jobs:
             prefix = job.s3_prefix
@@ -288,7 +288,7 @@ class SubmitJobRequestV2(BaseSettings):
                 raise ValueError(f"Duplicate jobs found for {prefix}")
             jobs_map[prefix].add(job_json)
         # check against any jobs in the context
-        current_jobs = (info.context or dict()).get("current_jobs", [])
+        current_jobs = (info.context or dict()).get("current_jobs", list())
         for job in current_jobs:
             prefix = job.get("s3_prefix")
             if (

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -7,7 +7,7 @@ import os
 import re
 from asyncio import gather, sleep
 from pathlib import PurePosixPath
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import boto3
 import requests
@@ -144,13 +144,13 @@ def get_parameter_value(param_name: str) -> dict:
 
 async def get_airflow_jobs(
     params: AirflowDagRunsRequestParameters, get_confs: bool = False
-) -> tuple[int, List[JobStatus] | List[dict]]:
+) -> tuple[int, Union[List[JobStatus], List[dict]]]:
     """Get Airflow jobs using input query params. If get_confs is true,
     only the job conf dictionaries are returned."""
 
     async def fetch_jobs(
         client: AsyncClient, url: str, request_body: dict
-    ) -> tuple[int, List[JobStatus] | List[dict]]:
+    ) -> tuple[int, Union[List[JobStatus], List[dict]]]:
         """Helper method to fetch jobs using httpx async client"""
         response = await client.post(url, json=request_body)
         response.raise_for_status()

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -184,7 +184,7 @@ async def get_airflow_jobs(
             request_body=params_dict,
         )
         # Fetch remaining jobs concurrently
-        tasks = []
+        tasks = list()
         offset = params_dict["page_offset"] + params_dict["page_limit"]
         while offset < total_entries:
             batch_params = {**params_dict, "page_offset": offset}

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -142,6 +142,62 @@ def get_parameter_value(param_name: str) -> dict:
     return param_value
 
 
+async def get_airflow_jobs(
+    params: AirflowDagRunsRequestParameters,
+) -> tuple[int, List[JobStatus]]:
+    """Get Airflow jobs using input query params"""
+
+    async def fetch_jobs(
+        client: AsyncClient, url: str, request_body: dict
+    ) -> tuple[int, List[JobStatus]]:
+        """Helper method to fetch jobs using httpx async client"""
+        response = await client.post(url, json=request_body)
+        response.raise_for_status()
+        response_jobs = response.json()
+        dag_runs = AirflowDagRunsResponse.model_validate_json(
+            json.dumps(response_jobs)
+        )
+        jobs_list = [
+            JobStatus.from_airflow_dag_run(d) for d in dag_runs.dag_runs
+        ]
+        total_entries = dag_runs.total_entries
+        return (total_entries, jobs_list)
+
+    airflow_url = os.getenv("AIND_AIRFLOW_SERVICE_JOBS_URL", "").strip("/")
+    airflow_url = f"{airflow_url}/~/dagRuns/list"
+    params_dict = json.loads(params.model_dump_json(exclude_none=True))
+    # Send request to Airflow to ListDagRuns
+    async with AsyncClient(
+        auth=(
+            os.getenv("AIND_AIRFLOW_SERVICE_USER"),
+            os.getenv("AIND_AIRFLOW_SERVICE_PASSWORD"),
+        )
+    ) as async_client:
+        # Fetch initial jobs
+        (total_entries, jobs_list) = await fetch_jobs(
+            client=async_client,
+            url=airflow_url,
+            request_body=params_dict,
+        )
+        # Fetch remaining jobs concurrently
+        tasks = []
+        offset = params_dict["page_offset"] + params_dict["page_limit"]
+        while offset < total_entries:
+            batch_params = {**params_dict, "page_offset": offset}
+            tasks.append(
+                fetch_jobs(
+                    client=async_client,
+                    url=airflow_url,
+                    request_body=batch_params,
+                )
+            )
+            offset += params_dict["page_limit"]
+        batches = await gather(*tasks)
+        for _, jobs_batch in batches:
+            jobs_list.extend(jobs_batch)
+    return (total_entries, jobs_list)
+
+
 async def validate_csv(request: Request):
     """Validate a csv or xlsx file. Return parsed contents as json."""
     logger.info("Received request to validate csv")
@@ -670,55 +726,12 @@ async def submit_hpc_jobs(request: Request):  # noqa: C901
 async def get_job_status_list(request: Request):
     """Get status of jobs using input query params."""
 
-    # TODO: resolved "shadows name from outer scope warnings"
-    async def fetch_jobs(
-        client: AsyncClient, url: str, request_body: dict
-    ) -> tuple[int, List[JobStatus]]:
-        """Helper method to fetch jobs using httpx async client"""
-        response = await client.post(url, json=request_body)
-        response.raise_for_status()
-        response_jobs = response.json()
-        dag_runs = AirflowDagRunsResponse.model_validate_json(
-            json.dumps(response_jobs)
-        )
-        job_status_list = [
-            JobStatus.from_airflow_dag_run(d) for d in dag_runs.dag_runs
-        ]
-        total_entries = dag_runs.total_entries
-        return (total_entries, job_status_list)
-
     try:
-        url = os.getenv("AIND_AIRFLOW_SERVICE_JOBS_URL", "").strip("/")
-        url = f"{url}/~/dagRuns/list"
         params = AirflowDagRunsRequestParameters.from_query_params(
             request.query_params
         )
         params_dict = json.loads(params.model_dump_json(exclude_none=True))
-        # Send request to Airflow to ListDagRuns
-        async with AsyncClient(
-            auth=(
-                os.getenv("AIND_AIRFLOW_SERVICE_USER"),
-                os.getenv("AIND_AIRFLOW_SERVICE_PASSWORD"),
-            )
-        ) as client:
-            # Fetch initial jobs
-            (total_entries, job_status_list) = await fetch_jobs(
-                client=client,
-                url=url,
-                request_body=params_dict,
-            )
-            # Fetch remaining jobs concurrently
-            tasks = []
-            offset = params_dict["page_offset"] + params_dict["page_limit"]
-            while offset < total_entries:
-                params = {**params_dict, "page_offset": offset}
-                tasks.append(
-                    fetch_jobs(client=client, url=url, request_body=params)
-                )
-                offset += params_dict["page_limit"]
-            batches = await gather(*tasks)
-            for _, jobs_batch in batches:
-                job_status_list.extend(jobs_batch)
+        total_entries, job_status_list = await get_airflow_jobs(params=params)
         status_code = 200
         message = "Retrieved job status list from airflow"
         data = {

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -427,9 +427,14 @@ async def submit_jobs_v2(request: Request):
     logger.info("Received request to submit jobs v2")
     content = await request.json()
     try:
+        params = AirflowDagRunsRequestParameters(
+            dag_ids=["transform_and_upload_v2"], states=["running", "queued"]
+        )
+        _, current_jobs = await get_airflow_jobs(params=params, get_confs=True)
         context = {
             "job_types": get_job_types("v2"),
             "project_names": get_project_names(),
+            "current_jobs": current_jobs,
         }
         with validation_context_v2(context):
             model = SubmitJobRequestV2.model_validate_json(json.dumps(content))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -386,7 +386,7 @@ class TestSubmitJobRequestV2(unittest.TestCase):
         job_configs = self.example_upload_config.model_dump(
             mode="json", exclude={"tasks"}
         )
-        upload_jobs = []
+        upload_jobs = list()
         for i in range(10):
             tasks = {
                 "modality_transformation_settings": Task(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -381,7 +381,8 @@ class TestSubmitJobRequestV2(unittest.TestCase):
         )
 
     def test_check_duplicate_upload_jobs_same_prefix(self):
-        """Tests jobs with same s3_prefix but different configs are allowed"""
+        """Tests that upload_jobs with same s3_prefix but different configs
+        are allowed"""
         job_configs = self.example_upload_config.model_dump(
             mode="json", exclude={"tasks"}
         )
@@ -395,6 +396,51 @@ class TestSubmitJobRequestV2(unittest.TestCase):
             upload_jobs.append(UploadJobConfigsV2(**job_configs, tasks=tasks))
         submit_job_request = SubmitJobRequestV2(upload_jobs=upload_jobs)
         self.assertEqual(10, len(submit_job_request.upload_jobs))
+
+    def test_current_jobs_validation(self):
+        """Tests job validation against current_jobs provided in context."""
+        job_configs = self.example_upload_config.model_dump(
+            mode="json", exclude={"subject_id"}
+        )
+        submitted_job_request = SubmitJobRequestV2(
+            upload_jobs=[
+                UploadJobConfigsV2(**job_configs, subject_id=subject_id)
+                for subject_id in ["123456", "123457", "123458"]
+            ]
+        )
+        current_jobs = [
+            j.model_dump(mode="json", exclude_none=True)
+            for j in submitted_job_request.upload_jobs
+        ]
+        new_job = UploadJobConfigsV2(**job_configs, subject_id="123459")
+        with validation_context({"current_jobs": current_jobs}):
+            submit_job_request = SubmitJobRequestV2(upload_jobs=[new_job])
+        self.assertEqual(1, len(submit_job_request.upload_jobs))
+        self.assertEqual(
+            "behavior_123459_2020-10-13_13-10-10",
+            submit_job_request.upload_jobs[0].s3_prefix,
+        )
+
+    def test_current_jobs_validation_fail(self):
+        """Tests job validation when an upload_job is already running."""
+        submitted_job_request = SubmitJobRequestV2(
+            upload_jobs=[self.example_upload_config]
+        )
+        current_jobs = [
+            j.model_dump(mode="json", exclude_none=True)
+            for j in submitted_job_request.upload_jobs
+        ]
+        with self.assertRaises(ValidationError) as err:
+            with validation_context({"current_jobs": current_jobs}):
+                SubmitJobRequestV2(upload_jobs=[self.example_upload_config])
+        err_msg = json.loads(err.exception.json())[0]["msg"]
+        self.assertEqual(
+            (
+                "Value error, Job is already running/queued for "
+                "behavior_123456_2020-10-13_13-10-10"
+            ),
+            err_msg,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -39,7 +39,10 @@ from aind_data_transfer_service.models.core import (
     Task,
     UploadJobConfigsV2,
 )
-from aind_data_transfer_service.models.internal import JobParamInfo
+from aind_data_transfer_service.models.internal import (
+    AirflowDagRunsRequestParameters,
+    JobParamInfo,
+)
 from aind_data_transfer_service.server import (
     app,
     get_job_types,
@@ -2101,26 +2104,28 @@ class TestServer(unittest.TestCase):
         mock_get_job_types.assert_called_once_with("v2")
         self.assertEqual(2, mock_get_project_names.call_count)
 
+    @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_job_types")
     @patch("aind_data_transfer_service.server.get_project_names")
     def test_validate_json(
         self,
         mock_get_project_names: MagicMock,
         mock_get_job_types: MagicMock,
+        mock_get_airflow_jobs: MagicMock,
     ):
         """Tests validate_json when json is valid."""
 
         mock_get_project_names.return_value = ["Ephys Platform"]
         mock_get_job_types.return_value = ["ecephys"]
+        mock_get_airflow_jobs.return_value = (0, [])
 
-        # shared
+        # v1
         ephys_source_dir = PurePosixPath("shared_drive/ephys_data/690165")
         s3_bucket = "private"
         subject_id = "690165"
         acq_datetime = datetime(2024, 2, 19, 11, 25, 17)
         platform = Platform.ECEPHYS
         project_name = "Ephys Platform"
-        # v1
         ephys_config = ModalityConfigs(
             modality=Modality.ECEPHYS,
             source=ephys_source_dir,
@@ -2162,21 +2167,30 @@ class TestServer(unittest.TestCase):
                 post_request_content, response_json["data"]["model_json"]
             )
             self.assertEqual(job["version"], response_json["data"]["version"])
+        expected_airflow_params = AirflowDagRunsRequestParameters(
+            dag_ids=["transform_and_upload_v2"], states=["running", "queued"]
+        )
+        mock_get_airflow_jobs.assert_called_once_with(
+            params=expected_airflow_params, get_confs=True
+        )
         mock_get_job_types.assert_called_once_with("v2")
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch("logging.Logger.warning")
+    @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
     def test_validate_json_invalid(
         self,
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
+        mock_get_airflow_jobs: MagicMock,
         mock_log_warning: MagicMock,
     ):
         """Tests validate_json when json is invalid."""
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
+        mock_get_airflow_jobs.return_value = (0, [])
         content = {"foo": "bar"}
         versions = {
             "v1": aind_data_transfer_models_version,
@@ -2199,17 +2213,65 @@ class TestServer(unittest.TestCase):
             mock_log_warning.assert_called_with(
                 f"There were validation errors processing {content}"
             )
+        mock_get_airflow_jobs.assert_called_once()
         mock_get_job_types.assert_called_once_with("v2")
         self.assertEqual(2, mock_get_project_names.call_count)
 
+    @patch("logging.Logger.warning")
+    @patch("httpx.AsyncClient.post")
+    @patch("aind_data_transfer_service.server.get_project_names")
+    @patch("aind_data_transfer_service.server.get_job_types")
+    def test_validate_json_v2_invalid_current_jobs(
+        self,
+        mock_get_job_types: MagicMock,
+        mock_get_project_names: MagicMock,
+        mock_post: MagicMock,
+        mock_log_warning: MagicMock,
+    ):
+        """Tests validate_json_v2 when there is a duplicate job running."""
+
+        mock_get_project_names.return_value = ["Ephys Platform"]
+        mock_get_job_types.return_value = ["ecephys"]
+        # assume a job is already running
+        job_request = SubmitJobRequestV2(
+            upload_jobs=[self.example_configs_v2]
+        ).model_dump(mode="json", exclude_none=True)
+        current_job = job_request["upload_jobs"][0]
+        airflow_response = {
+            "dag_runs": [{**self.get_dag_run_response, "conf": current_job}],
+            "total_entries": 1,
+        }
+        mock_dag_runs_response = Response()
+        mock_dag_runs_response.status_code = 200
+        mock_dag_runs_response._content = json.dumps(airflow_response).encode(
+            "utf-8"
+        )
+        mock_post.return_value = mock_dag_runs_response
+        # now submit same job again
+        with TestClient(app) as client:
+            resp = client.post("/api/v2/validate_json", json=job_request)
+            resp_json = resp.json()
+        self.assertEqual(406, resp.status_code)
+        self.assertEqual("There were validation errors", resp_json["message"])
+        self.assertIn(
+            "Job is already running/queued for "
+            "ecephys_690165_2024-02-19_11-25-17",
+            resp_json["data"]["errors"],
+        )
+        mock_log_warning.assert_called_once_with(
+            f"There were validation errors processing {job_request}"
+        )
+
     @patch("logging.Logger.exception")
     @patch("pydantic.BaseModel.model_validate_json")
+    @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
     def test_validate_json_error(
         self,
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
+        mock_get_airflow_jobs: MagicMock,
         mock_model_validate_json: MagicMock,
         mock_log_error: MagicMock,
     ):
@@ -2217,6 +2279,7 @@ class TestServer(unittest.TestCase):
 
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
+        mock_get_airflow_jobs.return_value = (0, [])
         mock_model_validate_json.side_effect = Exception("Unknown error")
         versions = {
             "v1": aind_data_transfer_models_version,
@@ -2244,6 +2307,7 @@ class TestServer(unittest.TestCase):
             )
             mock_model_validate_json.assert_called()
             mock_log_error.assert_called_with("Internal Server Error.")
+        mock_get_airflow_jobs.assert_called_once()
         mock_get_job_types.assert_called_once_with("v2")
         self.assertEqual(2, mock_get_project_names.call_count)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2233,6 +2233,7 @@ class TestServer(unittest.TestCase):
         mock_get_job_types.assert_called_once_with("v2")
         self.assertEqual(2, mock_get_project_names.call_count)
 
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("logging.Logger.warning")
     @patch("httpx.AsyncClient.post")
     @patch("aind_data_transfer_service.server.get_project_names")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1671,18 +1671,21 @@ class TestServer(unittest.TestCase):
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("logging.Logger.warning")
     @patch("requests.post")
+    @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
     def test_submit_v1_v2_jobs_406(
         self,
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
+        mock_get_airflow_jobs: MagicMock,
         mock_post: MagicMock,
         mock_log_warning: MagicMock,
     ):
         """Tests submit jobs 406 response."""
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
+        mock_get_airflow_jobs.return_value = (0, [])
         for version in ["v1", "v2"]:
             with TestClient(app) as client:
                 submit_job_response = client.post(
@@ -1694,21 +1697,25 @@ class TestServer(unittest.TestCase):
                 "There were validation errors processing {}"
             )
         mock_get_job_types.assert_called_once_with("v2")
+        mock_get_airflow_jobs.assert_called_once()
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("requests.post")
+    @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
     def test_submit_v1_v2_jobs_200(
         self,
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
+        mock_get_airflow_jobs: MagicMock,
         mock_post: MagicMock,
     ):
         """Tests submit jobs success."""
         mock_get_project_names.return_value = ["Ephys Platform"]
         mock_get_job_types.return_value = ["ecephys"]
+        mock_get_airflow_jobs.return_value = (0, [])
         mock_response = Response()
         mock_response.status_code = 200
         mock_response._content = json.dumps({"message": "sent"}).encode(
@@ -1762,23 +1769,27 @@ class TestServer(unittest.TestCase):
                 )
             self.assertEqual(200, submit_job_response.status_code)
         mock_get_job_types.assert_called_once_with("v2")
+        mock_get_airflow_jobs.assert_called_once()
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("requests.post")
     @patch("logging.Logger.exception")
+    @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
     def test_submit_v1_v2_jobs_500(
         self,
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
+        mock_get_airflow_jobs: MagicMock,
         mock_log_exception: MagicMock,
         mock_post: MagicMock,
     ):
         """Tests submit jobs 500 response."""
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
+        mock_get_airflow_jobs.return_value = (0, [])
         mock_post.side_effect = Exception("Something went wrong")
         request_json_v1 = {
             "user_email": None,
@@ -1854,6 +1865,7 @@ class TestServer(unittest.TestCase):
             self.assertEqual(500, submit_job_response.status_code)
             mock_log_exception.assert_called()
         mock_get_job_types.assert_called_once_with("v2")
+        mock_get_airflow_jobs.assert_called_once()
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
@@ -2041,18 +2053,21 @@ class TestServer(unittest.TestCase):
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("requests.post")
+    @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
     def test_submit_v2_jobs_200_basic_serialization(
         self,
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
+        mock_get_airflow_jobs: MagicMock,
         mock_post: MagicMock,
     ):
         """Tests submission when user posts standard pydantic json"""
 
         mock_get_project_names.return_value = ["Ephys Platform"]
         mock_get_job_types.return_value = ["ecephys"]
+        mock_get_airflow_jobs.return_value = (0, [])
 
         mock_response = Response()
         mock_response.status_code = 200
@@ -2102,6 +2117,7 @@ class TestServer(unittest.TestCase):
                 )
             self.assertEqual(200, submit_job_response.status_code)
         mock_get_job_types.assert_called_once_with("v2")
+        mock_get_airflow_jobs.assert_called_once()
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch("aind_data_transfer_service.server.get_airflow_jobs")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1685,7 +1685,7 @@ class TestServer(unittest.TestCase):
         """Tests submit jobs 406 response."""
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
-        mock_get_airflow_jobs.return_value = (0, [])
+        mock_get_airflow_jobs.return_value = (0, list())
         for version in ["v1", "v2"]:
             with TestClient(app) as client:
                 submit_job_response = client.post(
@@ -1715,7 +1715,7 @@ class TestServer(unittest.TestCase):
         """Tests submit jobs success."""
         mock_get_project_names.return_value = ["Ephys Platform"]
         mock_get_job_types.return_value = ["ecephys"]
-        mock_get_airflow_jobs.return_value = (0, [])
+        mock_get_airflow_jobs.return_value = (0, list())
         mock_response = Response()
         mock_response.status_code = 200
         mock_response._content = json.dumps({"message": "sent"}).encode(
@@ -1789,7 +1789,7 @@ class TestServer(unittest.TestCase):
         """Tests submit jobs 500 response."""
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
-        mock_get_airflow_jobs.return_value = (0, [])
+        mock_get_airflow_jobs.return_value = (0, list())
         mock_post.side_effect = Exception("Something went wrong")
         request_json_v1 = {
             "user_email": None,
@@ -2067,7 +2067,7 @@ class TestServer(unittest.TestCase):
 
         mock_get_project_names.return_value = ["Ephys Platform"]
         mock_get_job_types.return_value = ["ecephys"]
-        mock_get_airflow_jobs.return_value = (0, [])
+        mock_get_airflow_jobs.return_value = (0, list())
 
         mock_response = Response()
         mock_response.status_code = 200
@@ -2133,7 +2133,7 @@ class TestServer(unittest.TestCase):
 
         mock_get_project_names.return_value = ["Ephys Platform"]
         mock_get_job_types.return_value = ["ecephys"]
-        mock_get_airflow_jobs.return_value = (0, [])
+        mock_get_airflow_jobs.return_value = (0, list())
 
         # v1
         ephys_source_dir = PurePosixPath("shared_drive/ephys_data/690165")
@@ -2206,7 +2206,7 @@ class TestServer(unittest.TestCase):
         """Tests validate_json when json is invalid."""
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
-        mock_get_airflow_jobs.return_value = (0, [])
+        mock_get_airflow_jobs.return_value = (0, list())
         content = {"foo": "bar"}
         versions = {
             "v1": aind_data_transfer_models_version,
@@ -2237,7 +2237,7 @@ class TestServer(unittest.TestCase):
     @patch("httpx.AsyncClient.post")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
-    def test_validate_json_v2_invalid_current_jobs(
+    def test_validate_json_v2_invalid_current(
         self,
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
@@ -2295,7 +2295,7 @@ class TestServer(unittest.TestCase):
 
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
-        mock_get_airflow_jobs.return_value = (0, [])
+        mock_get_airflow_jobs.return_value = (0, list())
         mock_model_validate_json.side_effect = Exception("Unknown error")
         versions = {
             "v1": aind_data_transfer_models_version,


### PR DESCRIPTION
closes #60 

This PR adds validation to prevent users from submitting duplicate jobs:
- Adds validator to check that `SubmitJobRequestV2.upload_jobs` are distinct.
    - If the s3_prefixes are the same, full job configs are compared since chunked jobs may have the same prefix.
- Jobs submitted to `/api/v2/submit_jobs` or `/api/v2/validate_json` additionally check against currently running or queued jobs.

