### PR TITLE
fix: check current jobs from run_list_of_jobs dag

### DIFF
--- a/src/aind_data_transfer_service/models/core.py
+++ b/src/aind_data_transfer_service/models/core.py
@@ -290,11 +290,15 @@ class SubmitJobRequestV2(BaseSettings):
         # check against any jobs in the context
         current_jobs = (info.context or dict()).get("current_jobs", list())
         for job in current_jobs:
-            prefix = job.get("s3_prefix")
-            if (
-                prefix is not None
-                and prefix in jobs_map
-                and json.dumps(job, sort_keys=True) in jobs_map[prefix]
-            ):
-                raise ValueError(f"Job is already running/queued for {prefix}")
+            jobs_to_check = job.get("upload_jobs", [job])
+            for j in jobs_to_check:
+                prefix = j.get("s3_prefix")
+                if (
+                    prefix is not None
+                    and prefix in jobs_map
+                    and json.dumps(j, sort_keys=True) in jobs_map[prefix]
+                ):
+                    raise ValueError(
+                        f"Job is already running/queued for {prefix}"
+                    )
         return self

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -228,7 +228,7 @@ async def validate_csv(request: Request):
                 data = csv_io.getvalue()
             csv_reader = csv.DictReader(io.StringIO(data))
             params = AirflowDagRunsRequestParameters(
-                dag_ids=["transform_and_upload_v2"],
+                dag_ids=["transform_and_upload_v2", "run_list_of_jobs"],
                 states=["running", "queued"],
             )
             _, current_jobs = await get_airflow_jobs(
@@ -324,7 +324,8 @@ async def validate_json_v2(request: Request):
     content = await request.json()
     try:
         params = AirflowDagRunsRequestParameters(
-            dag_ids=["transform_and_upload_v2"], states=["running", "queued"]
+            dag_ids=["transform_and_upload_v2", "run_list_of_jobs"],
+            states=["running", "queued"],
         )
         _, current_jobs = await get_airflow_jobs(params=params, get_confs=True)
         context = {
@@ -439,7 +440,8 @@ async def submit_jobs_v2(request: Request):
     content = await request.json()
     try:
         params = AirflowDagRunsRequestParameters(
-            dag_ids=["transform_and_upload_v2"], states=["running", "queued"]
+            dag_ids=["transform_and_upload_v2", "run_list_of_jobs"],
+            states=["running", "queued"],
         )
         _, current_jobs = await get_airflow_jobs(params=params, get_confs=True)
         context = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -434,21 +434,27 @@ class TestSubmitJobRequestV2(unittest.TestCase):
         submitted_job_request = SubmitJobRequestV2(
             upload_jobs=[self.example_upload_config]
         )
-        current_jobs = [
+        current_jobs_1 = [
             j.model_dump(mode="json", exclude_none=True)
             for j in submitted_job_request.upload_jobs
         ]
-        with self.assertRaises(ValidationError) as err:
-            with validation_context({"current_jobs": current_jobs}):
-                SubmitJobRequestV2(upload_jobs=[self.example_upload_config])
-        err_msg = json.loads(err.exception.json())[0]["msg"]
-        self.assertEqual(
-            (
-                "Value error, Job is already running/queued for "
-                "behavior_123456_2020-10-13_13-10-10"
-            ),
-            err_msg,
-        )
+        current_jobs_2 = [
+            submitted_job_request.model_dump(mode="json", exclude_none=True)
+        ]
+        for current_jobs in [current_jobs_1, current_jobs_2]:
+            with self.assertRaises(ValidationError) as err:
+                with validation_context({"current_jobs": current_jobs}):
+                    SubmitJobRequestV2(
+                        upload_jobs=[self.example_upload_config]
+                    )
+            err_msg = json.loads(err.exception.json())[0]["msg"]
+            self.assertEqual(
+                (
+                    "Value error, Job is already running/queued for "
+                    "behavior_123456_2020-10-13_13-10-10"
+                ),
+                err_msg,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1602,6 +1602,13 @@ class TestServer(unittest.TestCase):
                 }
                 response = client.post(url="/api/v2/validate_csv", files=files)
 
+        expected_airflow_params = AirflowDagRunsRequestParameters(
+            dag_ids=["transform_and_upload_v2", "run_list_of_jobs"],
+            states=["running", "queued"],
+        )
+        mock_get_airflow_jobs.assert_called_once_with(
+            params=expected_airflow_params, get_confs=True
+        )
         self.assertEqual(200, response.status_code)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
@@ -1798,7 +1805,13 @@ class TestServer(unittest.TestCase):
                 )
             self.assertEqual(200, submit_job_response.status_code)
         mock_get_job_types.assert_called_once_with("v2")
-        mock_get_airflow_jobs.assert_called_once()
+        expected_airflow_params = AirflowDagRunsRequestParameters(
+            dag_ids=["transform_and_upload_v2", "run_list_of_jobs"],
+            states=["running", "queued"],
+        )
+        mock_get_airflow_jobs.assert_called_once_with(
+            params=expected_airflow_params, get_confs=True
+        )
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
@@ -2213,7 +2226,8 @@ class TestServer(unittest.TestCase):
             )
             self.assertEqual(job["version"], response_json["data"]["version"])
         expected_airflow_params = AirflowDagRunsRequestParameters(
-            dag_ids=["transform_and_upload_v2"], states=["running", "queued"]
+            dag_ids=["transform_and_upload_v2", "run_list_of_jobs"],
+            states=["running", "queued"],
         )
         mock_get_airflow_jobs.assert_called_once_with(
             params=expected_airflow_params, get_confs=True


### PR DESCRIPTION
fixes #255 

Updates validation context and validator to additionally process job confs from `run_list_of_jobs` dag when checking for duplicate jobs.