### PR TITLE
feat: admins can add/edit job type parameters in UI

### DIFF
--- a/docs/source/Contributing.rst
+++ b/docs/source/Contributing.rst
@@ -62,6 +62,7 @@ To run uvicorn locally:
 
 .. code:: bash
 
+   # export MSYS_NO_PATHCONV=1 # Uncomment this line if running on Windows
    export AIND_METADATA_SERVICE_PROJECT_NAMES_URL='http://aind-metadata-service-dev/project_names'
    export AIND_AIRFLOW_SERVICE_URL='http://aind-airflow-service-dev:8080/api/v1/dags/run_list_of_jobs/dagRuns'
    # export AIND_AIRFLOW_SERVICE_JOBS_URL='http://aind-airflow-service-dev:8080/api/v1/dags'

--- a/docs/source/UserGuideV1.rst
+++ b/docs/source/UserGuideV1.rst
@@ -520,6 +520,7 @@ Available job types and their configurations can be viewed at:
 http://aind-data-transfer-service/job_params
 
 To request a new job type, please reach out to Scientific Computing.
+Admins can manage job types directly in the Job Parameters page.
 
 Reporting bugs or making feature requests
 -----------------------------------------

--- a/docs/source/UserGuideV2.rst
+++ b/docs/source/UserGuideV2.rst
@@ -186,6 +186,7 @@ Available job types and their configurations can be viewed at:
 http://aind-data-transfer-service/job_params
 
 To request a new job type, please reach out to Scientific Computing.
+Admins can manage job types directly in the Job Parameters page.
 
 Reporting bugs or making feature requests
 -----------------------------------------

--- a/src/aind_data_transfer_service/models/internal.py
+++ b/src/aind_data_transfer_service/models/internal.py
@@ -272,6 +272,6 @@ class JobParamInfo(BaseModel):
     ) -> str:
         """Create the parameter name from job_type and task_id"""
         prefix = os.getenv("AIND_AIRFLOW_PARAM_PREFIX")
-        if version is None:
+        if version is None or version == "v1":
             return f"{prefix}/{job_type}/tasks/{task_id}"
         return f"{prefix}/{version}/{job_type}/tasks/{task_id}"

--- a/src/aind_data_transfer_service/models/internal.py
+++ b/src/aind_data_transfer_service/models/internal.py
@@ -241,6 +241,7 @@ class JobParamInfo(BaseModel):
 
     @field_validator("modality", mode="after")
     def validate_modality(cls, v):
+        """Check that modality is one of aind-data-schema modalities"""
         if v is not None and v not in JobParamInfo._MODALITIES_LIST:
             raise ValueError(
                 "Invalid modality: modality must be one of "

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -11,6 +11,7 @@ from typing import Any, List, Optional, Union
 
 import boto3
 import requests
+from aind_data_schema_models.modalities import Modality
 from aind_data_transfer_models import (
     __version__ as aind_data_transfer_models_version,
 )
@@ -95,6 +96,7 @@ templates = Jinja2Templates(directory=template_directory)
 logger = get_logger(log_configs=LoggingConfigs())
 project_names_url = os.getenv("AIND_METADATA_SERVICE_PROJECT_NAMES_URL")
 
+MODALITIES_LIST = list(Modality.abbreviation_map.keys())
 
 def get_project_names() -> List[str]:
     """Get a list of project_names"""
@@ -1020,12 +1022,13 @@ async def job_params(request: Request):
         name="job_params.html",
         context=(
             {
+                "user_signed_in": user is not None,
                 "project_names_url": os.getenv(
                     "AIND_METADATA_SERVICE_PROJECT_NAMES_URL"
                 ),
                 "versions": ["v1", "v2"],
                 "default_version": "v1",
-                "user_signed_in": user is not None,
+                "modalities": MODALITIES_LIST,
             }
         ),
     )

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -98,6 +98,7 @@ project_names_url = os.getenv("AIND_METADATA_SERVICE_PROJECT_NAMES_URL")
 
 MODALITIES_LIST = list(Modality.abbreviation_map.keys())
 
+
 def get_project_names() -> List[str]:
     """Get a list of project_names"""
     # TODO: Cache response for 5 minutes
@@ -1029,6 +1030,10 @@ async def job_params(request: Request):
                 "versions": ["v1", "v2"],
                 "default_version": "v1",
                 "modalities": MODALITIES_LIST,
+                "modality_tasks": [
+                    "modality_transformation_settings",
+                    "codeocean_pipeline_settings",
+                ],
             }
         ),
     )

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -1014,6 +1014,7 @@ async def jobs(request: Request):
 
 async def job_params(request: Request):
     """Get Job Parameters page"""
+    user = request.session.get("user")
     return templates.TemplateResponse(
         request=request,
         name="job_params.html",
@@ -1024,6 +1025,7 @@ async def job_params(request: Request):
                 ),
                 "versions": ["v1", "v2"],
                 "default_version": "v1",
+                "user_signed_in": user is not None,
             }
         ),
     )

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -176,7 +176,7 @@ def get_parameter_value(param_name: str) -> dict:
     return param_value
 
 
-def set_parameter_value(param_name: str, param_value: dict) -> Any:
+def put_parameter_value(param_name: str, param_value: dict) -> Any:
     """Set a parameter value in AWS param store based on parameter name"""
     param_value_str = json.dumps(param_value)
     ssm_client = boto3.client("ssm")
@@ -1118,7 +1118,7 @@ def get_parameter_v2(request: Request):
         )
 
 
-async def set_parameter(request: Request):
+async def put_parameter(request: Request):
     """Set v1/v2 parameter in AWS param store based on job_type and task_id"""
     # User must be signed in
     user = request.session.get("user")
@@ -1147,7 +1147,7 @@ async def set_parameter(request: Request):
     try:
         param_value = await request.json()
         logger.info(f"Setting parameter {param_name} to {param_value}")
-        result = set_parameter_value(
+        result = put_parameter_value(
             param_name=param_name, param_value=param_value
         )
         logger.info(result)
@@ -1158,7 +1158,7 @@ async def set_parameter(request: Request):
             },
             status_code=200,
         )
-    except ClientError as e:
+    except Exception as e:
         logger.exception(f"Error setting parameter {param_name}: {e}")
         return JSONResponse(
             content={
@@ -1285,7 +1285,7 @@ routes = [
     ),
     Route(
         "/api/{version:str}/parameters/job_types/{job_type:str}/tasks/{task_id:path}",
-        endpoint=set_parameter,
+        endpoint=put_parameter,
         methods=["PUT"],
     ),
     Route("/jobs", endpoint=jobs, methods=["GET"]),

--- a/src/aind_data_transfer_service/templates/admin.html
+++ b/src/aind_data_transfer_service/templates/admin.html
@@ -31,6 +31,15 @@
     <h3>Admin</h3>
     <div>Hello {{user_name}}, welcome to the admin page</div>
     <div>Email: {{user_email}}</div>
+    <h4 class="mt-4">Job Type Parameters</h4>
+     <div class="mb-2">
+      <div class="alert alert-info mb-0 p-4" role="alert">
+        To manage job type parameters, go to the <a href="/job_params" class="alert-link">Job Parameters</a> page.
+        Select an existing parameter, or click the
+        <button type="button" class="btn btn-success btn-sm" disabled><i class="bi bi-plus-circle"></i> Add New Parameter</button>
+        button.
+      </div>
+    </div>
   </div>
 </body>
 </html>

--- a/src/aind_data_transfer_service/templates/admin.html
+++ b/src/aind_data_transfer_service/templates/admin.html
@@ -24,8 +24,8 @@
     <a title="List of project names" href="{{ project_names_url }}" target="_blank">Project Names</a> |
     <a title="For more information click here" href="https://aind-data-transfer-service.readthedocs.io"
       target="_blank">Help</a> |
-    <a href="/admin">Admin</a> |
-    <a href="/logout">Log out</a>
+    <a href="/admin">Admin</a>
+    <a href="/logout" class="float-end">Log out</a>
   </nav>
   <div>
     <h3>Admin</h3>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -116,6 +116,12 @@
                 $(this).find('#param-modal-label').text('');
                 $(this).find('#param-modal-content').val('');
             });
+            $('#param-modal').on('click', '#reset-param-btn', function () {
+                var modal = $('#param-modal');
+                var paramName = modal.find('#param-modal-label').text();
+                var url = getParamUrlFromParamName(paramName);
+                loadParameterValue(url, modal);
+            });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
                 var version = $(this).text();
@@ -209,7 +215,17 @@
             }
             return data;
         }
-        // Method to load param values in the modal
+        // Methods to load param values in the modal
+        function getParamUrlFromParamName(paramName) {
+            if (paramName.includes('job_types/v2')) {
+                var version = 'v2';
+                var cleanedParamName = paramName.split('job_types/v2/')[1];
+            } else {
+                var version = 'v1';
+                var cleanedParamName = paramName.split('job_types/')[1];
+            }
+            return `/api/${version}/parameters/job_types/${cleanedParamName}`;
+        }
         function loadParameterValue(paramUrl, modal) {
             $.ajax({
                 url: paramUrl,

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -304,7 +304,6 @@
         }
         // Methods to load/submit/reset param values in the modal
         function getParamUrlFromParamInfo(version, jobType, taskId, modality) {
-            console.log(`Creating URL for ${version}, job type: ${jobType}, task ID: ${taskId}, modality: ${modality}`);
             var baseUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
             return modality ? `${baseUrl}/${modality}` : baseUrl;
         }
@@ -319,6 +318,7 @@
             return `/api/${version}/parameters/job_types/${cleanedParamName}`;
         }
         function loadParameterValue(paramUrl, modal) {
+            console.log(`Loading ${paramUrl} into ${modal.attr('id')}`);
             var modalContentSelector = (modal.attr('id') === 'param-modal') ? '#param-modal-content' : '#new-param-modal-content';
             $.ajax({
                 url: paramUrl,
@@ -334,6 +334,14 @@
             });
         }
         function submitParameterValue(paramUrl, paramValue, modal) {
+            console.log(`Submitting ${paramUrl} with value: ${paramValue}`);
+            try {
+                JSON.parse(paramValue);
+            } catch (e) {
+                console.error('Invalid JSON:', e.message);
+                alert('Parameter value must be valid JSON:\n' + e.message);
+                return;
+            }
             $.ajax({
                 url: paramUrl,
                 type: 'PUT',
@@ -342,6 +350,7 @@
                 success: function (response) {
                     console.log(`Successfully updated ${paramUrl}`);
                     alert(`Parameter updated successfully: ${response.data}`);
+                    // reload the content to verify and reformat changes
                     loadParameterValue(paramUrl, modal);
                 },
                 error: function (xhr, status, error) {
@@ -349,6 +358,26 @@
                     alert(`Failed to update parameter: ${error}`);
                 }
             });
+        }
+        // Methods for param modal updates
+        function toggleParamTextArea(isEnabled, modal){
+            modal.find('#new-param-modal-content').toggle(isEnabled);
+            modal.find('#new-param-modal-param-exists-alert').toggle(!isEnabled);
+            modal.find('#new-submit-param-btn').prop('disabled', !isEnabled);
+        }
+        function handleExistingParam(modal) {
+            var existing = false;
+            const version = getCurrentVersion();
+            const jobType = getInputValues('Job Type', modal).input;
+            const taskId = getInputValues('Task ID', modal).input;
+            const modality = MODALITY_TASKS.includes(taskId) ? getInputValues('Modality', modal).input : null;
+            if (jobType && taskId && (!MODALITY_TASKS.includes(taskId) || modality)) {
+                const table = $('#job-params-table').DataTable();
+                const searchStr = `/${jobType}/tasks/${taskId}` + (modality ? `/${modality}` : '');
+                existing = table.column('Parameter Name:title').data().toArray().find(val => val.endsWith(searchStr));
+                console.log(`Parameter already exists: ${existing}`);
+            }
+            toggleParamTextArea(!existing, modal);
         }
         function resetParamModal(modal) {
             // Resetting the Add New Parameter modal will clear all inputs
@@ -359,9 +388,8 @@
                 modal.find('#new-param-task-id-select').val('');
                 modal.find('#new-param-task-id-input').val('').hide();
                 modal.find('#new-param-modality-select').val('').parent().hide();
-                modal.find('#new-param-modal-content').val('').show();
-                modal.find('#new-param-modal-param-exists-alert').hide();
-                modal.find('#new-submit-param-btn').prop('disabled', false);
+                modal.find('#new-param-modal-content').val('');
+                toggleParamTextArea(true, modal);
             } else {
                 var paramName = modal.find('#param-modal-label').text();
                 var url = getParamUrlFromParamName(paramName);
@@ -401,27 +429,7 @@
                 alert(error);
                 throw new Error(error);
             }
-            return inputVal;
-        }
-        function checkExistingParam(modal) {
-            const version = getCurrentVersion();
-            const jobType = getInputValues('Job Type', modal).input;
-            const taskId = getInputValues('Task ID', modal).input;
-            const modality = MODALITY_TASKS.includes(taskId) ? getInputValues('Modality', modal).input : null;
-            if (!jobType || !taskId || (MODALITY_TASKS.includes(taskId) && !modality)) {
-                return false;
-            }
-            const table = $('#job-params-table').DataTable();
-            const searchStr = `/${jobType}/tasks/${taskId}` + (modality ? `/${modality}` : '');
-            const existing = table.column('Parameter Name:title').data().toArray().find(val => val.endsWith(searchStr));
-            return existing || false;
-        }
-        function handleExistingParam(modal) {
-            // Toggle textarea, message, and submit button based on existing parameter
-            var paramExists = checkExistingParam(modal);
-            modal.find('#new-param-modal-content').toggle(!paramExists);
-            modal.find('#new-param-modal-param-exists-alert').toggle(!!paramExists);
-            modal.find('#new-submit-param-btn').prop('disabled', !!paramExists);
+            return inputValues.input;
         }
     </script>
     </body>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -122,6 +122,13 @@
                 var url = getParamUrlFromParamName(paramName);
                 loadParameterValue(url, modal);
             });
+            $('#param-modal').on('click', '#submit-param-btn', function () {
+                var modal = $('#param-modal');
+                var paramName = modal.find('#param-modal-label').text();
+                var paramValue = modal.find('#param-modal-content').val();
+                var url = getParamUrlFromParamName(paramName);
+                submitParameterValue(url, paramValue, modal);
+            });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
                 var version = $(this).text();
@@ -215,7 +222,7 @@
             }
             return data;
         }
-        // Methods to load param values in the modal
+        // Methods to load/submit param values in the modal
         function getParamUrlFromParamName(paramName) {
             if (paramName.includes('job_types/v2')) {
                 var version = 'v2';
@@ -237,6 +244,23 @@
                 error: function (xhr, status, error) {
                     console.error(`Error fetching ${paramUrl}: ${error}`);
                     modal.find('#param-modal-content').val(error);
+                }
+            });
+        }
+        function submitParameterValue(paramUrl, paramValue, modal) {
+            $.ajax({
+                url: paramUrl,
+                type: 'PUT',
+                contentType: 'application/json',
+                data: paramValue,
+                success: function (response) {
+                    console.log(`Successfully updated ${paramUrl}`);
+                    alert(`Parameter updated successfully: ${response.data}`);
+                    loadParameterValue(paramUrl, modal);
+                },
+                error: function (xhr, status, error) {
+                    console.error(`Error updating ${paramUrl}: ${error}`);
+                    alert(`Failed to update parameter: ${error}`);
                 }
             });
         }

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -140,8 +140,27 @@
             createJobParamsTable();
             // Event listeners for modal to display/edit params
             $(`#${MODAL_ID}`).on('show.bs.modal', function(event) {
-                var button = $(event.relatedTarget);
-                onShowModal(button);
+                // Add New Parameter: set label and dropdown options
+                // Edit Existing Parameter: set label and load intital value
+                const eventTarget = $(event.relatedTarget);
+                const action = eventTarget.data('bs-action');
+                const modal = $(`#${MODAL_ID}`);
+                modal.data('bs-action', action); // save action type
+                const isNew = action === 'new';
+                modal.find(`#${MODAL_ID}-label`).text(isNew ? 'Add New Parameter' : eventTarget.data('bs-param-name'));
+                modal.find(`#${MODAL_ID}-version`).text(getCurrentVersion()).toggle(isNew);
+                modal.find(`#${MODAL_ID}-dropdowns`).toggle(isNew);
+                if (isNew) {
+                    ['Job Type', 'Task ID'].forEach(field => {
+                        const select = modal.find(`#${MODAL_ID}-${field.toLowerCase().replace(' ', '-')}-select`);
+                        select.empty()
+                            .append(`<option value="">Select ${field}</option>`)
+                            .append(getUniqueColumnValues(field).map(val => `<option value="${val}">${val}</option>`))
+                            .append(`<option value="__new__">Create new ${field}</option>`);
+                    });
+                } else {
+                    loadParameterValue(getParamUrlFromParamName(eventTarget.data('bs-param-name')));
+                }
             });
             $(`#${MODAL_ID}`).on('hidden.bs.modal', function() {
                 onResetModal();
@@ -150,7 +169,21 @@
                 onResetModal(true);
             });
             $(`#${MODAL_ID}`).on('click', `#${MODAL_ID}-submit-btn`, function() {
-                onSubmitModal();
+                const modal = $(`#${MODAL_ID}`);
+                const action = modal.data('bs-action');
+                let url;
+                if (action === "new") {
+                    const version = getCurrentVersion();
+                    const jobType = getValidatedInputValue('Job Type', modal);
+                    const taskId = getValidatedInputValue('Task ID', modal);
+                    const modality = MODALITY_TASKS.includes(taskId) ? getValidatedInputValue('Modality', modal) : null;
+                    url = getParamUrlFromParamInfo(version, jobType, taskId, modality);
+                } else {
+                    const paramName = modal.find(`#${MODAL_ID}-label`).text();
+                    url = getParamUrlFromParamName(paramName);
+                }
+                const paramValue = modal.find(`#${MODAL_ID}-content`).val();
+                submitParameterValue(url, paramValue);
             });
             $(`#${MODAL_ID}-job-type-select`).on('change', function() {
                 $(`#${MODAL_ID}-job-type-input`).toggle($(this).val() === '__new__').focus();
@@ -316,28 +349,6 @@
             }
             toggleParamTextArea(!exists);
         }
-        function onShowModal(eventTarget) {
-            // Add New Parameter: set label and dropdown options
-            // Edit Existing Parameter: set label and load intital value
-            const action = eventTarget.data('bs-action');
-            const modal = $(`#${MODAL_ID}`);
-            modal.data('bs-action', action); // save action type
-            const isNew = action === 'new';
-            modal.find(`#${MODAL_ID}-label`).text(isNew ? 'Add New Parameter' : eventTarget.data('bs-param-name'));
-            modal.find(`#${MODAL_ID}-version`).text(getCurrentVersion()).toggle(isNew);
-            modal.find(`#${MODAL_ID}-dropdowns`).toggle(isNew);
-            if (isNew) {
-                ['Job Type', 'Task ID'].forEach(field => {
-                    const select = modal.find(`#${MODAL_ID}-${field.toLowerCase().replace(' ', '-')}-select`);
-                    select.empty()
-                        .append(`<option value="">Select ${field}</option>`)
-                        .append(getUniqueColumnValues(field).map(val => `<option value="${val}">${val}</option>`))
-                        .append(`<option value="__new__">Create new ${field}</option>`);
-                });
-            } else {
-                loadParameterValue(getParamUrlFromParamName(eventTarget.data('bs-param-name')));
-            }
-        }
         function onResetModal(reload = false) {
             const modal = $(`#${MODAL_ID}`);
             const action = modal.data('bs-action');
@@ -355,23 +366,6 @@
                     modal.find(`#${MODAL_ID}-label, #${MODAL_ID}-content`).text('').val('');
                 }
             }
-        }
-        function onSubmitModal() {
-            const modal = $(`#${MODAL_ID}`);
-            const action = modal.data('bs-action');
-            let url;
-            if (action === "new") {
-                const version = getCurrentVersion();
-                const jobType = getValidatedInputValue('Job Type', modal);
-                const taskId = getValidatedInputValue('Task ID', modal);
-                const modality = MODALITY_TASKS.includes(taskId) ? getValidatedInputValue('Modality', modal) : null;
-                url = getParamUrlFromParamInfo(version, jobType, taskId, modality);
-            } else {
-                const paramName = modal.find(`#${MODAL_ID}-label`).text();
-                url = getParamUrlFromParamName(paramName);
-            }
-            const paramValue = modal.find(`#${MODAL_ID}-content`).val();
-            submitParameterValue(url, paramValue);
         }
         // Helper methods to get current values
         function getCurrentVersion() {

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -57,6 +57,54 @@
             </div>
             <span>Job Parameters</span>
         </h4>
+        <!-- button and modal for adding new parameters-->
+        {% if user_signed_in %}
+        <div class="mb-2">
+            <button type="button" class="btn btn-success btn-sm" id="add-param-btn">
+                <i class="bi bi-plus-circle"></i> Add New Parameter
+            </button>
+        </div>
+        <div class="modal fade" id="new-param-modal" tabindex="-1" aria-labelledby="new-param-modal-label" aria-hidden="true">
+                <div class="modal-dialog modal-xl">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="new-param-modal-label">Add New Parameter</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="row mb-2">
+                                <div class="col-md-4">
+                                    <label for="new-param-job-type" class="form-label">Job Type</label>
+                                    <select id="new-param-job-type-select" class="form-select form-select-sm mb-1">
+                                        <option value="">Select Job Type</option>
+                                        <option value="__custom__">New job type (enter manually)</option>
+                                    </select>
+                                    <input type="text" id="new-param-job-type-input" class="form-control form-control-sm mt-1" placeholder="Enter new job type" style="display:none;" />
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="new-param-task-id" class="form-label">Task ID</label>
+                                    <select id="new-param-task-id" class="form-select form-select-sm">
+                                        <option value="">Select Task ID</option>
+                                    </select>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="new-param-modality" class="form-label">Modality</label>
+                                    <select id="new-param-modality" class="form-select form-select-sm">
+                                        <option value="">Select Modality</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <textarea id="new-param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" placeholder='{"skip_task": false}'></textarea>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                            <button type="button" class="btn btn-secondary" id="new-reset-param-btn">Reset</button>
+                            <button type="button" class="btn btn-primary" id="new-submit-param-btn">Submit</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
         <!-- job params table -->
         <div>
             <table id="job-params-table" class="display compact table table-bordered table-sm" style="font-size: small">
@@ -71,7 +119,7 @@
                 </thead>
             </table>
             <!-- modal for displaying param value as json -->
-            <!-- if opened from Edit button, the textarea will be editable and the footer will display the Submit button -->
+            <!-- if user is signed in, the textarea will be editable and the footer will display the Submit button -->
             <div class="modal fade" id="param-modal" tabindex="-1" aria-labelledby="param-modal-label" aria-hidden="true">
                 <div class="modal-dialog modal-xl">
                     <div class="modal-content">
@@ -131,6 +179,18 @@
                 var paramValue = modal.find('#param-modal-content').val();
                 var url = getParamUrlFromParamName(paramName);
                 submitParameterValue(url, paramValue, modal);
+            });
+            // Event listeners for Add New Parameter modal
+            $('#add-param-btn').on('click', function() {
+                var modal = $('#new-param-modal');
+                modal.modal('show');
+            });
+            $('#new-param-job-type-select').on('change', function() {
+                if ($(this).val() === '__custom__') {
+                    $('#new-param-job-type-input').show().focus();
+                } else {
+                    $('#new-param-job-type-input').hide();
+                }
             });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -170,10 +170,7 @@
                 $(this).find('#param-modal-content').val('');
             });
             $('#param-modal').on('click', '#reset-param-btn', function () {
-                var modal = $('#param-modal');
-                var paramName = modal.find('#param-modal-label').text();
-                var url = getParamUrlFromParamName(paramName);
-                loadParameterValue(url, modal);
+                resetParamModal($('#param-modal'));
             });
             $('#param-modal').on('click', '#submit-param-btn', function () {
                 var modal = $('#param-modal');
@@ -204,7 +201,13 @@
             });
             $('#new-param-task-id-select').on('change', function() {
                 $('#new-param-task-id-input').toggle($(this).val() === '__new__').focus();
-                $('#new-param-modality-select').parent().toggle(MODALITY_TASKS.includes($(this).val()));
+                $('#new-param-modality-select').val('').parent().toggle(MODALITY_TASKS.includes($(this).val()));
+            });
+            $('#new-param-modal').on('hidden.bs.modal', function() {
+                resetParamModal($(this));
+            });
+            $('#new-param-modal').on('click', '#new-reset-param-btn', function () {
+                resetParamModal($('#new-param-modal'));
             });
             $('#new-param-modal').on('click', '#new-submit-param-btn', function () {
                 var modal = $('#new-param-modal');
@@ -214,6 +217,7 @@
                 var modality = (MODALITY_TASKS.includes(taskId)) ? getValidatedInputValue('Modality', modal) : null;
                 var url = getParamUrlFromParamInfo(version, jobType, taskId, modality);
                 var paramValue = modal.find('#new-param-modal-content').val();
+                submitParameterValue(url, paramValue, modal);
             });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
@@ -290,7 +294,7 @@
             }
             return data;
         }
-        // Methods to load/submit param values in the modal
+        // Methods to load/submit/reset param values in the modal
         function getParamUrlFromParamInfo(version, jobType, taskId, modality) {
             console.log(`Creating URL for ${version}, job type: ${jobType}, task ID: ${taskId}, modality: ${modality}`);
             var baseUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
@@ -307,16 +311,17 @@
             return `/api/${version}/parameters/job_types/${cleanedParamName}`;
         }
         function loadParameterValue(paramUrl, modal) {
+            var modalContentSelector = (modal.attr('id') === 'param-modal') ? '#param-modal-content' : '#new-param-modal-content';
             $.ajax({
                 url: paramUrl,
                 type: 'GET',
                 success: function (response) {
                     jsonStr = JSON.stringify(response.data, null, 3);
-                    modal.find('#param-modal-content').val(jsonStr);
+                    modal.find(modalContentSelector).val(jsonStr);
                 },
                 error: function (xhr, status, error) {
                     console.error(`Error fetching ${paramUrl}: ${error}`);
-                    modal.find('#param-modal-content').val(error);
+                    modal.find(modalContentSelector).val(error);
                 }
             });
         }
@@ -336,6 +341,22 @@
                     alert(`Failed to update parameter: ${error}`);
                 }
             });
+        }
+        function resetParamModal(modal) {
+            // Resetting the Add New Parameter modal will clear all inputs
+            // Resetting the Edit Existing Parameter modal will reload the parameter value
+            if (modal.attr('id') === 'new-param-modal') {
+                modal.find('#new-param-job-type-select').val('');
+                modal.find('#new-param-job-type-input').val('').hide();
+                modal.find('#new-param-task-id-select').val('');
+                modal.find('#new-param-task-id-input').val('').hide();
+                modal.find('#new-param-modality-select').val('').parent().hide();
+                modal.find('#new-param-modal-content').val('');
+            } else {
+                var paramName = modal.find('#param-modal-label').text();
+                var url = getParamUrlFromParamName(paramName);
+                loadParameterValue(url, modal);
+            }
         }
         // Helper methods to get current values
         function getCurrentVersion() {

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -68,24 +68,22 @@
                 <div class="modal-dialog modal-xl">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h5 class="modal-title" id="new-param-modal-label">Add New Parameter</h5>
+                            <h5 class="modal-title" id="new-param-modal-label">Add New Parameter
+                                <span class="badge bg-primary ms-2" id="new-param-modal-version"></span>
+                            </h5>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
                             <div class="row mb-2">
                                 <div class="col-md-4">
-                                    <label for="new-param-job-type" class="form-label">Job Type</label>
-                                    <select id="new-param-job-type-select" class="form-select form-select-sm mb-1">
-                                        <option value="">Select Job Type</option>
-                                        <option value="__custom__">New job type (enter manually)</option>
-                                    </select>
-                                    <input type="text" id="new-param-job-type-input" class="form-control form-control-sm mt-1" placeholder="Enter new job type" style="display:none;" />
+                                    <label for="new-param-job-type-select" class="form-label">Job Type</label>
+                                    <select id="new-param-job-type-select" class="form-select form-select-sm mb-1"></select>
+                                    <input type="text" id="new-param-job-type-input" class="form-control form-control-sm mt-1" placeholder="Enter new Job Type" style="display:none;" />
                                 </div>
                                 <div class="col-md-4">
-                                    <label for="new-param-task-id" class="form-label">Task ID</label>
-                                    <select id="new-param-task-id" class="form-select form-select-sm">
-                                        <option value="">Select Task ID</option>
-                                    </select>
+                                    <label for="new-param-task-id-select" class="form-label">Task ID</label>
+                                    <select id="new-param-task-id-select" class="form-select form-select-sm"></select>
+                                    <input type="text" id="new-param-task-id-input" class="form-control form-control-sm mt-1" placeholder="Enter new Task ID" style="display:none;" />
                                 </div>
                                 <div class="col-md-4">
                                     <label for="new-param-modality" class="form-label">Modality</label>
@@ -159,7 +157,7 @@
                 var modal = $(this);
                 modal.find('#param-modal-label').text(paramName);
                 // update modal contents
-                var version = $('#version-button').text().trim();
+                var version = getCurrentVersion();
                 var getParameterUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
                 if (modality) {
                     getParameterUrl += `/${modality}`;
@@ -186,19 +184,40 @@
             // Event listeners for Add New Parameter modal
             $('#add-param-btn').on('click', function() {
                 var modal = $('#new-param-modal');
+                // Set version badge in the modal
+                var version = getCurrentVersion();
+                modal.find('#new-param-modal-version').text(version);
+                // Set job type and task id dropdown options
+                ['Job Type','Task ID'].forEach(function(dropdown) {
+                    var values = getUniqueColumnValues(`${dropdown}:title`);
+                    var select = modal.find(`#new-param-${dropdown.toLowerCase().replace(' ', '-')}-select`);
+                    select.empty();
+                    select.append(`<option value="">Select ${dropdown}</option>`);
+                    values.forEach(function(val) {
+                        select.append(`<option value="${val}">${val}</option>`);
+                    });
+                    select.append(`<option value="__new__">Create new ${dropdown}</option>`);
+                });
                 modal.modal('show');
             });
             $('#new-param-job-type-select').on('change', function() {
-                if ($(this).val() === '__custom__') {
+                if ($(this).val() === '__new__') {
                     $('#new-param-job-type-input').show().focus();
                 } else {
                     $('#new-param-job-type-input').hide();
                 }
             });
+            $('#new-param-task-id-select').on('change', function() {
+                if ($(this).val() === '__new__') {
+                    $('#new-param-task-id-input').show().focus();
+                } else {
+                    $('#new-param-task-id-input').hide();
+                }
+            });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
                 var version = $(this).text();
-                if (version != $('#version-button').text().trim()) {
+                if (version != getCurrentVersion()) {
                     $('#version-button').text(version);
                     $('#job-params-table').DataTable().ajax.url(`/api/${version}/parameters`).load();
                 }
@@ -311,6 +330,13 @@
                     alert(`Failed to update parameter: ${error}`);
                 }
             });
+        }
+        // Helper methods to get current values
+        function getCurrentVersion() {
+            return $('#version-button').text().trim();
+        }
+        function getUniqueColumnValues(columnSelector) {
+            return Array.from(new Set($('#job-params-table').DataTable().column(columnSelector).data().toArray()));
         }
     </script>
     </body>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -60,57 +60,57 @@
         <!-- button and modal for adding new parameters-->
         {% if user_signed_in %}
         <div class="mb-2">
-            <button type="button" class="btn btn-success btn-sm" id="add-param-btn">
+            <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#new-param-modal">
                 <i class="bi bi-plus-circle"></i> Add New Parameter
             </button>
         </div>
         <div class="modal fade" id="new-param-modal" tabindex="-1" aria-labelledby="new-param-modal-label" aria-hidden="true">
-                <div class="modal-dialog modal-xl">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="new-param-modal-label">Add New Parameter
-                                <span class="badge bg-primary ms-2" id="new-param-modal-version"></span>
-                            </h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                        </div>
-                        <div class="modal-body">
-                            <!-- dropdowns for job type, task id and modality -->
-                            <div class="row mb-2">
-                                <div class="col-md-4">
-                                    <label for="new-param-job-type-select" class="form-label">Job Type</label>
-                                    <select id="new-param-job-type-select" class="form-select form-select-sm mb-1"></select>
-                                    <input type="text" id="new-param-job-type-input" class="form-control form-control-sm mt-1" placeholder="Enter new Job Type" style="display:none;" />
-                                </div>
-                                <div class="col-md-4">
-                                    <label for="new-param-task-id-select" class="form-label">Task ID</label>
-                                    <select id="new-param-task-id-select" class="form-select form-select-sm"></select>
-                                    <input type="text" id="new-param-task-id-input" class="form-control form-control-sm mt-1" placeholder="Enter new Task ID" style="display:none;" />
-                                </div>
-                                <div class="col-md-4" style="display:none;">
-                                    <label for="new-param-modality-select" class="form-label">Modality</label>
-                                    <select id="new-param-modality-select" class="form-select form-select-sm">
-                                        <option value="">Select Modality</option>
-                                        {% for modality in modalities %}
-                                            <option value="{{ modality }}">{{ modality }}</option>
-                                        {% endfor %}
-                                    </select>
-                                </div>
+            <div class="modal-dialog modal-xl">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="new-param-modal-label">Add New Parameter
+                            <span class="badge bg-primary ms-2" id="new-param-modal-version"></span>
+                        </h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <!-- dropdowns for job type, task id and modality -->
+                        <div class="row mb-2">
+                            <div class="col-md-4">
+                                <label for="new-param-modal-job-type-select" class="form-label">Job Type</label>
+                                <select id="new-param-modal-job-type-select" class="form-select form-select-sm mb-1"></select>
+                                <input type="text" id="new-param-modal-job-type-input" class="form-control form-control-sm mt-1" placeholder="Enter new Job Type" style="display:none;" />
                             </div>
-                            <!-- textarea for parameter json value -->
-                            <textarea id="new-param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" placeholder='{"skip_task": false}'></textarea>
-                            <!-- message if parameter already exists -->
-                            <div id="new-param-modal-param-exists-alert" class="alert alert-info" role="alert" style="display:none;">
-                                This parameter already exists! To edit, please click on the parameter from the Job Parameters table.
+                            <div class="col-md-4">
+                                <label for="new-param-modal-task-id-select" class="form-label">Task ID</label>
+                                <select id="new-param-modal-task-id-select" class="form-select form-select-sm"></select>
+                                <input type="text" id="new-param-modal-task-id-input" class="form-control form-control-sm mt-1" placeholder="Enter new Task ID" style="display:none;" />
+                            </div>
+                            <div class="col-md-4" style="display:none;">
+                                <label for="new-param-modal-modality-select" class="form-label">Modality</label>
+                                <select id="new-param-modal-modality-select" class="form-select form-select-sm">
+                                    <option value="">Select Modality</option>
+                                    {% for modality in modalities %}
+                                    <option value="{{ modality }}">{{ modality }}</option>
+                                    {% endfor %}
+                                </select>
                             </div>
                         </div>
-                        <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                            <button type="button" class="btn btn-secondary" id="new-reset-param-btn">Reset</button>
-                            <button type="button" class="btn btn-primary" id="new-submit-param-btn">Submit</button>
+                        <!-- textarea for parameter json value -->
+                        <textarea id="new-param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" placeholder='{"skip_task": false}'></textarea>
+                        <!-- message if parameter already exists -->
+                        <div id="new-param-modal-param-exists-alert" class="alert alert-info" role="alert" style="display:none;">
+                            This parameter already exists! To edit, please click on the parameter from the Job Parameters table.
                         </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" id="new-param-modal-reset-btn">Reset</button>
+                        <button type="button" class="btn btn-primary" id="new-param-modal-submit-btn">Submit</button>
                     </div>
                 </div>
             </div>
+        </div>
         {% endif %}
         <!-- job params table -->
         <div>
@@ -140,8 +140,8 @@
                         {% if user_signed_in %}
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                            <button type="button" class="btn btn-secondary" id="reset-param-btn">Reset</button>
-                            <button type="button" class="btn btn-primary" id="submit-param-btn">Submit</button>
+                            <button type="button" class="btn btn-secondary" id="param-modal-reset-btn">Reset</button>
+                            <button type="button" class="btn btn-primary" id="param-modal-submit-btn">Submit</button>
                         </div>
                         {% endif %}
                     </div>
@@ -151,89 +151,53 @@
     </div>
     <script>
         const MODALITY_TASKS = {{ modality_tasks | tojson }}; // from Jinja context
+        const MODAL_ID_EDIT = 'param-modal';
+        const MODAL_ID_ADD = 'new-param-modal';
         $(document).ready(function() {
             createJobParamsTable();
-            // Event listeners for param value modal
-            // show modal: load param value
-            $('#param-modal').on('show.bs.modal', function(event) {
+            // Event listeners for param value modals
+            // show modal: load param value or set up for new param
+            $(`#${MODAL_ID_EDIT}`).on('show.bs.modal', function(event) {
                 var button = $(event.relatedTarget);
-                var paramName = button.data('bs-param-name');
-                var jobType = button.data('bs-job-type');
-                var taskId = button.data('bs-task-id');
-                var modality = button.data('bs-modality');
-                // update the modal label and footer
-                var modal = $(this);
-                modal.find('#param-modal-label').text(paramName);
-                // update modal contents
-                var version = getCurrentVersion();
-                var getParameterUrl = getParamUrlFromParamInfo(version, jobType, taskId, modality);
-                loadParameterValue(getParameterUrl, modal);
+                onShowModal(MODAL_ID_EDIT, button);
             });
-            // hide modal: clear all values
-            $('#param-modal').on('hidden.bs.modal', function() {
-                $(this).find('#param-modal-label').text('');
-                $(this).find('#param-modal-content').val('');
+            $(`#${MODAL_ID_ADD}`).on('show.bs.modal', function(event) {
+                onShowModal(MODAL_ID_ADD);
             });
-            // reset: reload param value
-            $('#param-modal').on('click', '#reset-param-btn', function () {
-                resetParamModal($('#param-modal'));
+            // hide modal: clear all inputs
+            $(`#${MODAL_ID_EDIT}`).on('hidden.bs.modal', function() {
+                onResetModal(MODAL_ID_EDIT);
             });
-            // submit: post param to api
-            $('#param-modal').on('click', '#submit-param-btn', function () {
-                var modal = $('#param-modal');
-                var paramName = modal.find('#param-modal-label').text();
-                var paramValue = modal.find('#param-modal-content').val();
-                var url = getParamUrlFromParamName(paramName);
-                submitParameterValue(url, paramValue, modal);
+            $(`#${MODAL_ID_ADD}`).on('hidden.bs.modal', function() {
+                onResetModal(MODAL_ID_ADD);
             });
-            // Event listeners for Add New Parameter modal
-            // show modal: set version badge, job type and task id dropdowns
-            $('#add-param-btn').on('click', function() {
-                var modal = $('#new-param-modal');
-                // Set version badge in the modal
-                var version = getCurrentVersion();
-                modal.find('#new-param-modal-version').text(version);
-                // Set job type and task id dropdown options
-                ['Job Type','Task ID'].forEach(function(dropdown) {
-                    var values = getUniqueColumnValues(`${dropdown}:title`);
-                    var select = modal.find(`#new-param-${dropdown.toLowerCase().replace(' ', '-')}-select`);
-                    select.empty();
-                    select.append(`<option value="">Select ${dropdown}</option>`);
-                    values.forEach(val => select.append(`<option value="${val}">${val}</option>`));
-                    select.append(`<option value="__new__">Create new ${dropdown}</option>`);
-                });
-                modal.modal('show');
+            // reset: reload param value or clear all inputs
+            $(`#${MODAL_ID_EDIT}`).on('click', `#${MODAL_ID_EDIT}-reset-btn`, function() {
+                onResetModal(MODAL_ID_EDIT, true);
             });
+            $(`#${MODAL_ID_ADD}`).on('click', `#${MODAL_ID_ADD}-reset-btn`, function() {
+                onResetModal(MODAL_ID_ADD);
+            });
+            // submit: validate and post param to api
+            $(`#${MODAL_ID_EDIT}`).on('click', `#${MODAL_ID_EDIT}-submit-btn`, function() {
+                onSubmitModal(MODAL_ID_EDIT);
+            });
+            $(`#${MODAL_ID_ADD}`).on('click', `#${MODAL_ID_ADD}-submit-btn`, function() {
+                onSubmitModal(MODAL_ID_ADD);
+            });
+            // only for Add New Parameter modal
             // update dropdowns based on selection
-            $('#new-param-job-type-select').on('change', function() {
-                $('#new-param-job-type-input').toggle($(this).val() === '__new__').focus();
-                handleExistingParam($('#new-param-modal'));
+            $(`#${MODAL_ID_ADD}-job-type-select`).on('change', function() {
+                $(`#${MODAL_ID_ADD}-job-type-input`).toggle($(this).val() === '__new__').focus();
+                handleExistingParam(MODAL_ID_ADD);
             });
-            $('#new-param-task-id-select').on('change', function() {
-                $('#new-param-task-id-input').toggle($(this).val() === '__new__').focus();
-                $('#new-param-modality-select').val('').parent().toggle(MODALITY_TASKS.includes($(this).val()));
-                handleExistingParam($('#new-param-modal'));
+            $(`#${MODAL_ID_ADD}-task-id-select`).on('change', function() {
+                $(`#${MODAL_ID_ADD}-task-id-input`).toggle($(this).val() === '__new__').focus();
+                $(`#${MODAL_ID_ADD}-modality-select`).val('').parent().toggle(MODALITY_TASKS.includes($(this).val()));
+                handleExistingParam(MODAL_ID_ADD);
             });
-            $('#new-param-modality-select').on('change', function() {
-                handleExistingParam($('#new-param-modal'));
-            });
-            // hide/reset modal: clear all inputs
-            $('#new-param-modal').on('hidden.bs.modal', function() {
-                resetParamModal($(this));
-            });
-            $('#new-param-modal').on('click', '#new-reset-param-btn', function () {
-                resetParamModal($('#new-param-modal'));
-            });
-            // submit: validate inputs and submit new param to api
-            $('#new-param-modal').on('click', '#new-submit-param-btn', function () {
-                var modal = $('#new-param-modal');
-                var version = getCurrentVersion();
-                var jobType = getValidatedInputValue('Job Type', modal);
-                var taskId = getValidatedInputValue('Task ID', modal);
-                var modality = (MODALITY_TASKS.includes(taskId)) ? getValidatedInputValue('Modality', modal) : null;
-                var url = getParamUrlFromParamInfo(version, jobType, taskId, modality);
-                var paramValue = modal.find('#new-param-modal-content').val();
-                submitParameterValue(url, paramValue, modal);
+            $(`#${MODAL_ID_ADD}-modality-select`).on('change', function() {
+                handleExistingParam(MODAL_ID_ADD);
             });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
@@ -299,7 +263,7 @@
                 return (
                     `<button type="button" class="btn btn-link btn-sm" 
                         data-bs-toggle="modal" 
-                        data-bs-target="#param-modal" 
+                        data-bs-target="#${MODAL_ID_EDIT}"
                         data-bs-param-name=${data} 
                         data-bs-job-type=${row.job_type} 
                         data-bs-task-id=${row.task_id}
@@ -326,8 +290,8 @@
             return `/api/${version}/parameters/job_types/${cleanedParamName}`;
         }
         function loadParameterValue(paramUrl, modal) {
-            console.log(`Loading ${paramUrl} into ${modal.attr('id')}`);
-            var modalContentSelector = (modal.attr('id') === 'param-modal') ? '#param-modal-content' : '#new-param-modal-content';
+            console.log(`Loading ${paramUrl}`);
+            const modalContentSelector = `#${modal.attr('id')}-content`;
             $.ajax({
                 url: paramUrl,
                 type: 'GET',
@@ -375,11 +339,13 @@
         }
         // Methods for param modal updates
         function toggleParamTextArea(isEnabled, modal){
-            modal.find('#new-param-modal-content').toggle(isEnabled);
-            modal.find('#new-param-modal-param-exists-alert').toggle(!isEnabled);
-            modal.find('#new-submit-param-btn').prop('disabled', !isEnabled);
+            const modalId = modal.attr('id');
+            modal.find(`#${modalId}-content`).toggle(isEnabled);
+            modal.find(`#${modalId}-param-exists-alert`).toggle(!isEnabled);
+            modal.find(`#${modalId}-submit-btn`).prop('disabled', !isEnabled);
         }
-        function handleExistingParam(modal) {
+        function handleExistingParam(modalId) {
+            var modal = $(`#${modalId}`);
             var existing = false;
             const version = getCurrentVersion();
             const jobType = getInputValues('Job Type', modal).input;
@@ -393,22 +359,71 @@
             }
             toggleParamTextArea(!existing, modal);
         }
-        function resetParamModal(modal) {
+        function onShowModal(modalId, eventTarget = null) {
+            var modal = $(`#${modalId}`);
+            if (modalId === MODAL_ID_ADD) {
+                // Set version badge in the modal
+                var version = getCurrentVersion();
+                modal.find(`#${modalId}-version`).text(version);
+                // Set job type and task id dropdown options
+                ['Job Type', 'Task ID'].forEach(function(dropdown) {
+                    var values = getUniqueColumnValues(`${dropdown}:title`);
+                    var select = modal.find(`#${modalId}-${dropdown.toLowerCase().replace(' ', '-')}-select`);
+                    select.empty();
+                    select.append(`<option value="">Select ${dropdown}</option>`);
+                    values.forEach(val => select.append(`<option value="${val}">${val}</option>`));
+                    select.append(`<option value="__new__">Create new ${dropdown}</option>`);
+                });
+            } else {
+                var paramName = eventTarget.data('bs-param-name');
+                var jobType = eventTarget.data('bs-job-type');
+                var taskId = eventTarget.data('bs-task-id');
+                var modality = eventTarget.data('bs-modality');
+                // update the modal label and contents
+                modal.find(`#${modalId}-label`).text(paramName);
+                var version = getCurrentVersion();
+                var getParameterUrl = getParamUrlFromParamInfo(version, jobType, taskId, modality);
+                loadParameterValue(getParameterUrl, modal);
+            }
+        }
+        function onResetModal(modalId, isReload = false) {
             // Resetting the Add New Parameter modal will clear all inputs
             // Resetting the Edit Existing Parameter modal will reload the parameter value
-            if (modal.attr('id') === 'new-param-modal') {
-                modal.find('#new-param-job-type-select').val('');
-                modal.find('#new-param-job-type-input').val('').hide();
-                modal.find('#new-param-task-id-select').val('');
-                modal.find('#new-param-task-id-input').val('').hide();
-                modal.find('#new-param-modality-select').val('').parent().hide();
-                modal.find('#new-param-modal-content').val('');
+            var modal = $(`#${modalId}`);
+            if (modalId === MODAL_ID_ADD) {
+                modal.find(`#${modalId}-job-type-select`).val('');
+                modal.find(`#${modalId}-job-type-input`).val('').hide();
+                modal.find(`#${modalId}-task-id-select`).val('');
+                modal.find(`#${modalId}-task-id-input`).val('').hide();
+                modal.find(`#${modalId}-modality-select`).val('').parent().hide();
+                modal.find(`#${modalId}-content`).val('');
                 toggleParamTextArea(true, modal);
             } else {
-                var paramName = modal.find('#param-modal-label').text();
-                var url = getParamUrlFromParamName(paramName);
-                loadParameterValue(url, modal);
+                if (isReload) {
+                    var paramName = modal.find(`#${modalId}-label`).text();
+                    var url = getParamUrlFromParamName(paramName);
+                    loadParameterValue(url, modal);
+                } else {
+                    modal.find(`#${modalId}-label`).text('');
+                    modal.find(`#${modalId}-content`).val('');
+                }
             }
+        }
+        function onSubmitModal(modalId) {
+            var modal = $(`#${modalId}`);
+            let url;
+            if (modalId === MODAL_ID_ADD) {
+                var version = getCurrentVersion();
+                var jobType = getValidatedInputValue('Job Type', modal);
+                var taskId = getValidatedInputValue('Task ID', modal);
+                var modality = (MODALITY_TASKS.includes(taskId)) ? getValidatedInputValue('Modality', modal) : null;
+                url = getParamUrlFromParamInfo(version, jobType, taskId, modality);
+            } else {
+                var paramName = modal.find(`#${modalId}-label`).text();
+                url = getParamUrlFromParamName(paramName);
+            }
+            var paramValue = modal.find(`#${modalId}-content`).val();
+            submitParameterValue(url, paramValue, modal);
         }
         // Helper methods to get current values
         function getCurrentVersion() {
@@ -418,11 +433,12 @@
             return Array.from(new Set($('#job-params-table').DataTable().column(columnSelector).data().toArray()));
         }
         function getInputValues(inputField, modal) {
-            var selector = inputField.toLowerCase().replace(' ', '-');
-            var dropdownVal = modal.find(`#new-param-${selector}-select`).val().trim();
+            const modalId = modal.attr('id');
+            const selector = inputField.toLowerCase().replace(' ', '-');
+            var dropdownVal = modal.find(`#${modalId}-${selector}-select`).val().trim();
             return {
                 dropdown: dropdownVal,
-                input: (dropdownVal === '__new__') ? modal.find(`#new-param-${selector}-input`).val().trim() : dropdownVal
+                input: (dropdownVal === '__new__') ? modal.find(`#${modalId}-${selector}-input`).val().trim() : dropdownVal
             };
         }
         function getValidatedInputValue(inputField, modal) {
@@ -446,5 +462,5 @@
             return inputValues.input;
         }
     </script>
-    </body>
+</body>
 </html>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -273,7 +273,7 @@
             }
             return data;
         }
-        // Methods to load/submit/reset param values in the modal
+        // Methods to load/submit param values in the modal
         function getParamUrlFromParamInfo(version, jobType, taskId, modality) {
             var baseUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
             return modality ? `${baseUrl}/${modality}` : baseUrl;

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -154,6 +154,7 @@
         $(document).ready(function() {
             createJobParamsTable();
             // Event listeners for param value modal
+            // show modal: load param value
             $('#param-modal').on('show.bs.modal', function(event) {
                 var button = $(event.relatedTarget);
                 var paramName = button.data('bs-param-name');
@@ -168,13 +169,16 @@
                 var getParameterUrl = getParamUrlFromParamInfo(version, jobType, taskId, modality);
                 loadParameterValue(getParameterUrl, modal);
             });
+            // hide modal: clear all values
             $('#param-modal').on('hidden.bs.modal', function() {
                 $(this).find('#param-modal-label').text('');
                 $(this).find('#param-modal-content').val('');
             });
+            // reset: reload param value
             $('#param-modal').on('click', '#reset-param-btn', function () {
                 resetParamModal($('#param-modal'));
             });
+            // submit: post param to api
             $('#param-modal').on('click', '#submit-param-btn', function () {
                 var modal = $('#param-modal');
                 var paramName = modal.find('#param-modal-label').text();
@@ -183,6 +187,7 @@
                 submitParameterValue(url, paramValue, modal);
             });
             // Event listeners for Add New Parameter modal
+            // show modal: set version badge, job type and task id dropdowns
             $('#add-param-btn').on('click', function() {
                 var modal = $('#new-param-modal');
                 // Set version badge in the modal
@@ -199,6 +204,7 @@
                 });
                 modal.modal('show');
             });
+            // update dropdowns based on selection
             $('#new-param-job-type-select').on('change', function() {
                 $('#new-param-job-type-input').toggle($(this).val() === '__new__').focus();
                 handleExistingParam($('#new-param-modal'));
@@ -211,12 +217,14 @@
             $('#new-param-modality-select').on('change', function() {
                 handleExistingParam($('#new-param-modal'));
             });
+            // hide/reset modal: clear all inputs
             $('#new-param-modal').on('hidden.bs.modal', function() {
                 resetParamModal($(this));
             });
             $('#new-param-modal').on('click', '#new-reset-param-btn', function () {
                 resetParamModal($('#new-param-modal'));
             });
+            // submit: validate inputs and submit new param to api
             $('#new-param-modal').on('click', '#new-submit-param-btn', function () {
                 var modal = $('#new-param-modal');
                 var version = getCurrentVersion();
@@ -354,8 +362,14 @@
                     loadParameterValue(paramUrl, modal);
                 },
                 error: function (xhr, status, error) {
-                    console.error(`Error updating ${paramUrl}: ${error}`);
-                    alert(`Failed to update parameter: ${error}`);
+                    var msg = `Error submitting parameter: ${error}`;
+                    try {
+                        msg += `\n\n${JSON.stringify(JSON.parse(xhr.responseText), null, 3)}`;
+                    } catch (e) {
+                        console.error('Failed to parse error response:', e.message);
+                    }
+                    console.error(msg);
+                    alert(msg);
                 }
             });
         }

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -85,9 +85,9 @@
                                     <select id="new-param-task-id-select" class="form-select form-select-sm"></select>
                                     <input type="text" id="new-param-task-id-input" class="form-control form-control-sm mt-1" placeholder="Enter new Task ID" style="display:none;" />
                                 </div>
-                                <div class="col-md-4">
-                                    <label for="new-param-modality" class="form-label">Modality</label>
-                                    <select id="new-param-modality" class="form-select form-select-sm">
+                                <div class="col-md-4" style="display:none;">
+                                    <label for="new-param-modality-select" class="form-label">Modality</label>
+                                    <select id="new-param-modality-select" class="form-select form-select-sm">
                                         <option value="">Select Modality</option>
                                         {% for modality in modalities %}
                                             <option value="{{ modality }}">{{ modality }}</option>
@@ -144,6 +144,7 @@
         </div>
     </div>
     <script>
+        const MODALITY_TASKS = {{ modality_tasks | tojson }}; // from Jinja context
         $(document).ready(function() {
             createJobParamsTable();
             // Event listeners for param value modal
@@ -201,18 +202,11 @@
                 modal.modal('show');
             });
             $('#new-param-job-type-select').on('change', function() {
-                if ($(this).val() === '__new__') {
-                    $('#new-param-job-type-input').show().focus();
-                } else {
-                    $('#new-param-job-type-input').hide();
-                }
+                $('#new-param-job-type-input').toggle($(this).val() === '__new__').focus();
             });
             $('#new-param-task-id-select').on('change', function() {
-                if ($(this).val() === '__new__') {
-                    $('#new-param-task-id-input').show().focus();
-                } else {
-                    $('#new-param-task-id-input').hide();
-                }
+                $('#new-param-task-id-input').toggle($(this).val() === '__new__').focus();
+                $('#new-param-modality-select').parent().toggle(MODALITY_TASKS.includes($(this).val()));
             });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -36,6 +36,11 @@
         <a title="List of project names" href= "{{ project_names_url }}" target="_blank" >Project Names</a> |
         <a title="For more information click here" href="https://aind-data-transfer-service.readthedocs.io"  target="_blank" >Help</a> |
         <a href="/admin">Admin</a>
+        {% if user_signed_in %}
+            <a href="/logout" class="float-end">Log out</a>
+        {% else %}
+            <a href="/login" class="float-end">Log in</a>
+        {% endif %}
     </nav>
     <div class="content">
         <h4 class="mb-2">
@@ -62,7 +67,6 @@
                         <th>Modality</th>
                         <th>Parameter Name</th>
                         <th>Last Modified</th>
-                        <th>Actions</th>
                     </tr>
                 </thead>
             </table>
@@ -76,13 +80,15 @@
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
-                            <textarea id="param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" readonly></textarea>
+                            <textarea id="param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" {% if not user_signed_in %}readonly{% endif %}></textarea>
                         </div>
-                        <div class="modal-footer" hidden>
+                        {% if user_signed_in %}
+                        <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
                             <button type="button" class="btn btn-secondary" id="reset-param-btn">Reset</button>
                             <button type="button" class="btn btn-primary" id="submit-param-btn">Submit</button>
                         </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -98,12 +104,9 @@
                 var jobType = button.data('bs-job-type');
                 var taskId = button.data('bs-task-id');
                 var modality = button.data('bs-modality');
-                var editEnabled = button.data('bs-edit-enabled');
                 // update the modal label and footer
                 var modal = $(this);
                 modal.find('#param-modal-label').text(paramName);
-                modal.find('.modal-footer').attr('hidden', !editEnabled);
-                modal.find('#param-modal-content').attr('readonly', !editEnabled);
                 // update modal contents
                 var version = $('#version-button').text().trim();
                 var getParameterUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
@@ -152,7 +155,6 @@
                     { data: 'modality', searchPanes: {show: false} },
                     { data: 'name', render: renderParameterButton },
                     { data: 'last_modified', render: renderDatetime },
-                    { data: 'name', render: renderActionButtons }
                 ],
                 order: [0, 'asc'],
                 // preselect "default" job_type
@@ -199,25 +201,8 @@
                         data-bs-job-type=${row.job_type} 
                         data-bs-task-id=${row.task_id}
                         data-bs-modality=${row.modality}
-                        data-bs-edit-enabled="false"
                     >${data}
                     </button>`
-                );
-            }
-            return data;
-        }
-        function renderActionButtons(data, type, row) {
-            if (type == 'display') {
-                return (
-                    `<button type="button" class="btn btn-secondary btn-sm" 
-                        data-bs-toggle="modal" 
-                        data-bs-target="#param-modal" 
-                        data-bs-param-name=${data} 
-                        data-bs-job-type=${row.job_type} 
-                        data-bs-task-id=${row.task_id}
-                        data-bs-modality=${row.modality}
-                        data-bs-edit-enabled="true"
-                    >Edit</button>`
                 );
             }
             return data;

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -74,6 +74,7 @@
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
+                            <!-- dropdowns for job type, task id and modality -->
                             <div class="row mb-2">
                                 <div class="col-md-4">
                                     <label for="new-param-job-type-select" class="form-label">Job Type</label>
@@ -95,7 +96,12 @@
                                     </select>
                                 </div>
                             </div>
+                            <!-- textarea for parameter json value -->
                             <textarea id="new-param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" placeholder='{"skip_task": false}'></textarea>
+                            <!-- message if parameter already exists -->
+                            <div id="new-param-modal-param-exists-alert" class="alert alert-info" role="alert" style="display:none;">
+                                This parameter already exists! To edit, please click on the parameter from the Job Parameters table.
+                            </div>
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
@@ -159,10 +165,7 @@
                 modal.find('#param-modal-label').text(paramName);
                 // update modal contents
                 var version = getCurrentVersion();
-                var getParameterUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
-                if (modality) {
-                    getParameterUrl += `/${modality}`;
-                }
+                var getParameterUrl = getParamUrlFromParamInfo(version, jobType, taskId, modality);
                 loadParameterValue(getParameterUrl, modal);
             });
             $('#param-modal').on('hidden.bs.modal', function() {
@@ -198,10 +201,15 @@
             });
             $('#new-param-job-type-select').on('change', function() {
                 $('#new-param-job-type-input').toggle($(this).val() === '__new__').focus();
+                handleExistingParam($('#new-param-modal'));
             });
             $('#new-param-task-id-select').on('change', function() {
                 $('#new-param-task-id-input').toggle($(this).val() === '__new__').focus();
                 $('#new-param-modality-select').val('').parent().toggle(MODALITY_TASKS.includes($(this).val()));
+                handleExistingParam($('#new-param-modal'));
+            });
+            $('#new-param-modality-select').on('change', function() {
+                handleExistingParam($('#new-param-modal'));
             });
             $('#new-param-modal').on('hidden.bs.modal', function() {
                 resetParamModal($(this));
@@ -351,7 +359,9 @@
                 modal.find('#new-param-task-id-select').val('');
                 modal.find('#new-param-task-id-input').val('').hide();
                 modal.find('#new-param-modality-select').val('').parent().hide();
-                modal.find('#new-param-modal-content').val('');
+                modal.find('#new-param-modal-content').val('').show();
+                modal.find('#new-param-modal-param-exists-alert').hide();
+                modal.find('#new-submit-param-btn').prop('disabled', false);
             } else {
                 var paramName = modal.find('#param-modal-label').text();
                 var url = getParamUrlFromParamName(paramName);
@@ -365,20 +375,26 @@
         function getUniqueColumnValues(columnSelector) {
             return Array.from(new Set($('#job-params-table').DataTable().column(columnSelector).data().toArray()));
         }
-        function getValidatedInputValue(inputField, modal) {
+        function getInputValues(inputField, modal) {
             var selector = inputField.toLowerCase().replace(' ', '-');
             var dropdownVal = modal.find(`#new-param-${selector}-select`).val().trim();
-            var inputVal = (dropdownVal === '__new__') ? modal.find(`#new-param-${selector}-input`).val().trim() : dropdownVal;
+            return {
+                dropdown: dropdownVal,
+                input: (dropdownVal === '__new__') ? modal.find(`#new-param-${selector}-input`).val().trim() : dropdownVal
+            };
+        }
+        function getValidatedInputValue(inputField, modal) {
             // Check for empty string, spaces, slashes, or existing values
+            var inputValues = getInputValues(inputField, modal);
             var error = false;
-            if (!inputVal) {
+            if (!inputValues.input) {
                 error = `${inputField} cannot be empty`;
-            } else if (inputVal.includes(' ') || inputVal.includes('/')) {
+            } else if (inputValues.input.includes(' ') || inputValues.input.includes('/')) {
                 error = `${inputField} cannot contain spaces or slashes`;
-            } else if (dropdownVal === '__new__') {
+            } else if (inputValues.dropdown === '__new__') {
                 var existingValues = getUniqueColumnValues(`${inputField}:title`);
-                if (existingValues.map(val => val.toLowerCase()).includes(inputVal.toLowerCase())) {
-                    error = `${inputField} "${inputVal}" already exists. Please select it from the dropdown.`;
+                if (existingValues.map(val => val.toLowerCase()).includes(inputValues.input.toLowerCase())) {
+                    error = `${inputField} "${inputValues.input}" already exists. Please select it from the dropdown.`;
                 }
             }
             if (error) {
@@ -386,6 +402,26 @@
                 throw new Error(error);
             }
             return inputVal;
+        }
+        function checkExistingParam(modal) {
+            const version = getCurrentVersion();
+            const jobType = getInputValues('Job Type', modal).input;
+            const taskId = getInputValues('Task ID', modal).input;
+            const modality = MODALITY_TASKS.includes(taskId) ? getInputValues('Modality', modal).input : null;
+            if (!jobType || !taskId || (MODALITY_TASKS.includes(taskId) && !modality)) {
+                return false;
+            }
+            const table = $('#job-params-table').DataTable();
+            const searchStr = `/${jobType}/tasks/${taskId}` + (modality ? `/${modality}` : '');
+            const existing = table.column('Parameter Name:title').data().toArray().find(val => val.endsWith(searchStr));
+            return existing || false;
+        }
+        function handleExistingParam(modal) {
+            // Toggle textarea, message, and submit button based on existing parameter
+            var paramExists = checkExistingParam(modal);
+            modal.find('#new-param-modal-content').toggle(!paramExists);
+            modal.find('#new-param-modal-param-exists-alert').toggle(!!paramExists);
+            modal.find('#new-submit-param-btn').prop('disabled', !!paramExists);
         }
     </script>
     </body>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -91,6 +91,9 @@
                                     <label for="new-param-modality" class="form-label">Modality</label>
                                     <select id="new-param-modality" class="form-select form-select-sm">
                                         <option value="">Select Modality</option>
+                                        {% for modality in modalities %}
+                                            <option value="{{ modality }}">{{ modality }}</option>
+                                        {% endfor %}
                                     </select>
                                 </div>
                             </div>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -194,9 +194,7 @@
                     var select = modal.find(`#new-param-${dropdown.toLowerCase().replace(' ', '-')}-select`);
                     select.empty();
                     select.append(`<option value="">Select ${dropdown}</option>`);
-                    values.forEach(function(val) {
-                        select.append(`<option value="${val}">${val}</option>`);
-                    });
+                    values.forEach(val => select.append(`<option value="${val}">${val}</option>`));
                     select.append(`<option value="__new__">Create new ${dropdown}</option>`);
                 });
                 modal.modal('show');
@@ -207,6 +205,15 @@
             $('#new-param-task-id-select').on('change', function() {
                 $('#new-param-task-id-input').toggle($(this).val() === '__new__').focus();
                 $('#new-param-modality-select').parent().toggle(MODALITY_TASKS.includes($(this).val()));
+            });
+            $('#new-param-modal').on('click', '#new-submit-param-btn', function () {
+                var modal = $('#new-param-modal');
+                var version = getCurrentVersion();
+                var jobType = getValidatedInputValue('Job Type', modal);
+                var taskId = getValidatedInputValue('Task ID', modal);
+                var modality = (MODALITY_TASKS.includes(taskId)) ? getValidatedInputValue('Modality', modal) : null;
+                var url = getParamUrlFromParamInfo(version, jobType, taskId, modality);
+                var paramValue = modal.find('#new-param-modal-content').val();
             });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
@@ -284,6 +291,11 @@
             return data;
         }
         // Methods to load/submit param values in the modal
+        function getParamUrlFromParamInfo(version, jobType, taskId, modality) {
+            console.log(`Creating URL for ${version}, job type: ${jobType}, task ID: ${taskId}, modality: ${modality}`);
+            var baseUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
+            return modality ? `${baseUrl}/${modality}` : baseUrl;
+        }
         function getParamUrlFromParamName(paramName) {
             if (paramName.includes('job_types/v2')) {
                 var version = 'v2';
@@ -331,6 +343,28 @@
         }
         function getUniqueColumnValues(columnSelector) {
             return Array.from(new Set($('#job-params-table').DataTable().column(columnSelector).data().toArray()));
+        }
+        function getValidatedInputValue(inputField, modal) {
+            var selector = inputField.toLowerCase().replace(' ', '-');
+            var dropdownVal = modal.find(`#new-param-${selector}-select`).val().trim();
+            var inputVal = (dropdownVal === '__new__') ? modal.find(`#new-param-${selector}-input`).val().trim() : dropdownVal;
+            // Check for empty string, spaces, slashes, or existing values
+            var error = false;
+            if (!inputVal) {
+                error = `${inputField} cannot be empty`;
+            } else if (inputVal.includes(' ') || inputVal.includes('/')) {
+                error = `${inputField} cannot contain spaces or slashes`;
+            } else if (dropdownVal === '__new__') {
+                var existingValues = getUniqueColumnValues(`${inputField}:title`);
+                if (existingValues.map(val => val.toLowerCase()).includes(inputVal.toLowerCase())) {
+                    error = `${inputField} "${inputVal}" already exists. Please select it from the dropdown.`;
+                }
+            }
+            if (error) {
+                alert(error);
+                throw new Error(error);
+            }
+            return inputVal;
         }
     </script>
     </body>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -60,56 +60,9 @@
         <!-- button and modal for adding new parameters-->
         {% if user_signed_in %}
         <div class="mb-2">
-            <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#new-param-modal">
+            <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#param-modal" data-bs-action="new">
                 <i class="bi bi-plus-circle"></i> Add New Parameter
             </button>
-        </div>
-        <div class="modal fade" id="new-param-modal" tabindex="-1" aria-labelledby="new-param-modal-label" aria-hidden="true">
-            <div class="modal-dialog modal-xl">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="new-param-modal-label">Add New Parameter
-                            <span class="badge bg-primary ms-2" id="new-param-modal-version"></span>
-                        </h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <!-- dropdowns for job type, task id and modality -->
-                        <div class="row mb-2">
-                            <div class="col-md-4">
-                                <label for="new-param-modal-job-type-select" class="form-label">Job Type</label>
-                                <select id="new-param-modal-job-type-select" class="form-select form-select-sm mb-1"></select>
-                                <input type="text" id="new-param-modal-job-type-input" class="form-control form-control-sm mt-1" placeholder="Enter new Job Type" style="display:none;" />
-                            </div>
-                            <div class="col-md-4">
-                                <label for="new-param-modal-task-id-select" class="form-label">Task ID</label>
-                                <select id="new-param-modal-task-id-select" class="form-select form-select-sm"></select>
-                                <input type="text" id="new-param-modal-task-id-input" class="form-control form-control-sm mt-1" placeholder="Enter new Task ID" style="display:none;" />
-                            </div>
-                            <div class="col-md-4" style="display:none;">
-                                <label for="new-param-modal-modality-select" class="form-label">Modality</label>
-                                <select id="new-param-modal-modality-select" class="form-select form-select-sm">
-                                    <option value="">Select Modality</option>
-                                    {% for modality in modalities %}
-                                    <option value="{{ modality }}">{{ modality }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </div>
-                        <!-- textarea for parameter json value -->
-                        <textarea id="new-param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" placeholder='{"skip_task": false}'></textarea>
-                        <!-- message if parameter already exists -->
-                        <div id="new-param-modal-param-exists-alert" class="alert alert-info" role="alert" style="display:none;">
-                            This parameter already exists! To edit, please click on the parameter from the Job Parameters table.
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                        <button type="button" class="btn btn-secondary" id="new-param-modal-reset-btn">Reset</button>
-                        <button type="button" class="btn btn-primary" id="new-param-modal-submit-btn">Submit</button>
-                    </div>
-                </div>
-            </div>
         </div>
         {% endif %}
         <!-- job params table -->
@@ -132,10 +85,41 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h5 class="modal-title" id="param-modal-label"></h5>
+                            <span class="badge bg-primary ms-2" id="param-modal-version"></span>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
-                            <textarea id="param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" {% if not user_signed_in %}readonly{% endif %}></textarea>
+                            <!-- dropdowns for Add New Parameter -->
+                            <div class="row mb-2" id="param-modal-dropdowns" style="display:none;">
+                                <div class="col-md-4">
+                                    <label for="param-modal-job-type-select" class="form-label">Job Type</label>
+                                    <select id="param-modal-job-type-select" class="form-select form-select-sm mb-1"></select>
+                                    <input type="text" id="param-modal-job-type-input" class="form-control form-control-sm mt-1" placeholder="Enter new Job Type" style="display:none;" />
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="param-modal-task-id-select" class="form-label">Task ID</label>
+                                    <select id="param-modal-task-id-select" class="form-select form-select-sm"></select>
+                                    <input type="text" id="param-modal-task-id-input" class="form-control form-control-sm mt-1" placeholder="Enter new Task ID" style="display:none;" />
+                                </div>
+                                <div class="col-md-4" style="display:none;">
+                                    <label for="param-modal-modality-select" class="form-label">Modality</label>
+                                    <select id="param-modal-modality-select" class="form-select form-select-sm">
+                                        <option value="">Select Modality</option>
+                                        {% for modality in modalities %}
+                                        <option value="{{ modality }}">{{ modality }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </div>
+                            <!-- textarea for parameter value -->
+                            <textarea
+                                id="param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15"
+                                placeholder='{"skip_task": false}' {% if not user_signed_in %}readonly{% endif %}
+                            ></textarea>
+                            <!-- message if parameter already exists -->
+                            <div id="param-modal-param-exists-alert" class="alert alert-info" role="alert" style="display:none;">
+                                This parameter already exists! To edit, please click on the parameter from the Job Parameters table.
+                            </div>
                         </div>
                         {% if user_signed_in %}
                         <div class="modal-footer">
@@ -151,53 +135,34 @@
     </div>
     <script>
         const MODALITY_TASKS = {{ modality_tasks | tojson }}; // from Jinja context
-        const MODAL_ID_EDIT = 'param-modal';
-        const MODAL_ID_ADD = 'new-param-modal';
+        const MODAL_ID = 'param-modal';
         $(document).ready(function() {
             createJobParamsTable();
-            // Event listeners for param value modals
-            // show modal: load param value or set up for new param
-            $(`#${MODAL_ID_EDIT}`).on('show.bs.modal', function(event) {
+            // Event listeners for modal to display/edit params
+            $(`#${MODAL_ID}`).on('show.bs.modal', function(event) {
                 var button = $(event.relatedTarget);
-                onShowModal(MODAL_ID_EDIT, button);
+                onShowModal(button);
             });
-            $(`#${MODAL_ID_ADD}`).on('show.bs.modal', function(event) {
-                onShowModal(MODAL_ID_ADD);
+            $(`#${MODAL_ID}`).on('hidden.bs.modal', function() {
+                onResetModal();
             });
-            // hide modal: clear all inputs
-            $(`#${MODAL_ID_EDIT}`).on('hidden.bs.modal', function() {
-                onResetModal(MODAL_ID_EDIT);
+            $(`#${MODAL_ID}`).on('click', `#${MODAL_ID}-reset-btn`, function() {
+                onResetModal(true);
             });
-            $(`#${MODAL_ID_ADD}`).on('hidden.bs.modal', function() {
-                onResetModal(MODAL_ID_ADD);
+            $(`#${MODAL_ID}`).on('click', `#${MODAL_ID}-submit-btn`, function() {
+                onSubmitModal();
             });
-            // reset: reload param value or clear all inputs
-            $(`#${MODAL_ID_EDIT}`).on('click', `#${MODAL_ID_EDIT}-reset-btn`, function() {
-                onResetModal(MODAL_ID_EDIT, true);
+            $(`#${MODAL_ID}-job-type-select`).on('change', function() {
+                $(`#${MODAL_ID}-job-type-input`).toggle($(this).val() === '__new__').focus();
+                handleExistingParam();
             });
-            $(`#${MODAL_ID_ADD}`).on('click', `#${MODAL_ID_ADD}-reset-btn`, function() {
-                onResetModal(MODAL_ID_ADD);
+            $(`#${MODAL_ID}-task-id-select`).on('change', function() {
+                $(`#${MODAL_ID}-task-id-input`).toggle($(this).val() === '__new__').focus();
+                $(`#${MODAL_ID}-modality-select`).val('').parent().toggle(MODALITY_TASKS.includes($(this).val()));
+                handleExistingParam();
             });
-            // submit: validate and post param to api
-            $(`#${MODAL_ID_EDIT}`).on('click', `#${MODAL_ID_EDIT}-submit-btn`, function() {
-                onSubmitModal(MODAL_ID_EDIT);
-            });
-            $(`#${MODAL_ID_ADD}`).on('click', `#${MODAL_ID_ADD}-submit-btn`, function() {
-                onSubmitModal(MODAL_ID_ADD);
-            });
-            // only for Add New Parameter modal
-            // update dropdowns based on selection
-            $(`#${MODAL_ID_ADD}-job-type-select`).on('change', function() {
-                $(`#${MODAL_ID_ADD}-job-type-input`).toggle($(this).val() === '__new__').focus();
-                handleExistingParam(MODAL_ID_ADD);
-            });
-            $(`#${MODAL_ID_ADD}-task-id-select`).on('change', function() {
-                $(`#${MODAL_ID_ADD}-task-id-input`).toggle($(this).val() === '__new__').focus();
-                $(`#${MODAL_ID_ADD}-modality-select`).val('').parent().toggle(MODALITY_TASKS.includes($(this).val()));
-                handleExistingParam(MODAL_ID_ADD);
-            });
-            $(`#${MODAL_ID_ADD}-modality-select`).on('change', function() {
-                handleExistingParam(MODAL_ID_ADD);
+            $(`#${MODAL_ID}-modality-select`).on('change', function() {
+                handleExistingParam();
             });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
@@ -263,7 +228,8 @@
                 return (
                     `<button type="button" class="btn btn-link btn-sm" 
                         data-bs-toggle="modal" 
-                        data-bs-target="#${MODAL_ID_EDIT}"
+                        data-bs-target="#${MODAL_ID}"
+                        data-bs-action="edit"
                         data-bs-param-name=${data} 
                         data-bs-job-type=${row.job_type} 
                         data-bs-task-id=${row.task_id}
@@ -280,37 +246,30 @@
             return modality ? `${baseUrl}/${modality}` : baseUrl;
         }
         function getParamUrlFromParamName(paramName) {
-            if (paramName.includes('job_types/v2')) {
-                var version = 'v2';
-                var cleanedParamName = paramName.split('job_types/v2/')[1];
-            } else {
-                var version = 'v1';
-                var cleanedParamName = paramName.split('job_types/')[1];
-            }
+            const match = paramName.match(/job_types\/(v\d+)?\/?(.*)/);
+            const version = match && match[1] ? match[1] : 'v1';
+            const cleanedParamName = match ? match[2] : paramName;
             return `/api/${version}/parameters/job_types/${cleanedParamName}`;
         }
-        function loadParameterValue(paramUrl, modal) {
-            console.log(`Loading ${paramUrl}`);
-            const modalContentSelector = `#${modal.attr('id')}-content`;
+        function loadParameterValue(paramUrl) {
+            const modal = $(`#${MODAL_ID}`);
             $.ajax({
                 url: paramUrl,
                 type: 'GET',
                 success: function (response) {
                     jsonStr = JSON.stringify(response.data, null, 3);
-                    modal.find(modalContentSelector).val(jsonStr);
+                    modal.find(`#${MODAL_ID}-content`).val(jsonStr);
                 },
                 error: function (xhr, status, error) {
                     console.error(`Error fetching ${paramUrl}: ${error}`);
-                    modal.find(modalContentSelector).val(error);
+                    modal.find(`#${MODAL_ID}-content`).val(error);
                 }
             });
         }
-        function submitParameterValue(paramUrl, paramValue, modal) {
-            console.log(`Submitting ${paramUrl} with value: ${paramValue}`);
+        function submitParameterValue(paramUrl, paramValue) {
             try {
                 JSON.parse(paramValue);
             } catch (e) {
-                console.error('Invalid JSON:', e.message);
                 alert('Parameter value must be valid JSON:\n' + e.message);
                 return;
             }
@@ -320,10 +279,9 @@
                 contentType: 'application/json',
                 data: paramValue,
                 success: function (response) {
-                    console.log(`Successfully updated ${paramUrl}`);
-                    alert(`Parameter updated successfully: ${response.data}`);
+                    alert('Parameter updated successfully');
                     // reload the content to verify and reformat changes
-                    loadParameterValue(paramUrl, modal);
+                    loadParameterValue(paramUrl);
                 },
                 error: function (xhr, status, error) {
                     var msg = `Error submitting parameter: ${error}`;
@@ -338,15 +296,15 @@
             });
         }
         // Methods for param modal updates
-        function toggleParamTextArea(isEnabled, modal){
-            const modalId = modal.attr('id');
-            modal.find(`#${modalId}-content`).toggle(isEnabled);
-            modal.find(`#${modalId}-param-exists-alert`).toggle(!isEnabled);
-            modal.find(`#${modalId}-submit-btn`).prop('disabled', !isEnabled);
+        function toggleParamTextArea(isEnabled){
+            const modal = $(`#${MODAL_ID}`);
+            modal.find(`#${MODAL_ID}-content`).toggle(isEnabled);
+            modal.find(`#${MODAL_ID}-param-exists-alert`).toggle(!isEnabled);
+            modal.find(`#${MODAL_ID}-submit-btn`).prop('disabled', !isEnabled);
         }
-        function handleExistingParam(modalId) {
-            var modal = $(`#${modalId}`);
-            var existing = false;
+        function handleExistingParam() {
+            let exists = false;
+            const modal = $(`#${MODAL_ID}`);
             const version = getCurrentVersion();
             const jobType = getInputValues('Job Type', modal).input;
             const taskId = getInputValues('Task ID', modal).input;
@@ -354,112 +312,99 @@
             if (jobType && taskId && (!MODALITY_TASKS.includes(taskId) || modality)) {
                 const table = $('#job-params-table').DataTable();
                 const searchStr = `/${jobType}/tasks/${taskId}` + (modality ? `/${modality}` : '');
-                existing = table.column('Parameter Name:title').data().toArray().find(val => val.endsWith(searchStr));
-                console.log(`Parameter already exists: ${existing}`);
+                exists = table.column('Parameter Name:title').data().toArray().some(val => val.endsWith(searchStr));
             }
-            toggleParamTextArea(!existing, modal);
+            toggleParamTextArea(!exists);
         }
-        function onShowModal(modalId, eventTarget = null) {
-            var modal = $(`#${modalId}`);
-            if (modalId === MODAL_ID_ADD) {
-                // Set version badge in the modal
-                var version = getCurrentVersion();
-                modal.find(`#${modalId}-version`).text(version);
-                // Set job type and task id dropdown options
-                ['Job Type', 'Task ID'].forEach(function(dropdown) {
-                    var values = getUniqueColumnValues(`${dropdown}:title`);
-                    var select = modal.find(`#${modalId}-${dropdown.toLowerCase().replace(' ', '-')}-select`);
-                    select.empty();
-                    select.append(`<option value="">Select ${dropdown}</option>`);
-                    values.forEach(val => select.append(`<option value="${val}">${val}</option>`));
-                    select.append(`<option value="__new__">Create new ${dropdown}</option>`);
+        function onShowModal(eventTarget) {
+            // Add New Parameter: set label and dropdown options
+            // Edit Existing Parameter: set label and load intital value
+            const action = eventTarget.data('bs-action');
+            const modal = $(`#${MODAL_ID}`);
+            modal.data('bs-action', action); // save action type
+            const isNew = action === 'new';
+            modal.find(`#${MODAL_ID}-label`).text(isNew ? 'Add New Parameter' : eventTarget.data('bs-param-name'));
+            modal.find(`#${MODAL_ID}-version`).text(getCurrentVersion()).toggle(isNew);
+            modal.find(`#${MODAL_ID}-dropdowns`).toggle(isNew);
+            if (isNew) {
+                ['Job Type', 'Task ID'].forEach(field => {
+                    const select = modal.find(`#${MODAL_ID}-${field.toLowerCase().replace(' ', '-')}-select`);
+                    select.empty()
+                        .append(`<option value="">Select ${field}</option>`)
+                        .append(getUniqueColumnValues(field).map(val => `<option value="${val}">${val}</option>`))
+                        .append(`<option value="__new__">Create new ${field}</option>`);
                 });
             } else {
-                var paramName = eventTarget.data('bs-param-name');
-                var jobType = eventTarget.data('bs-job-type');
-                var taskId = eventTarget.data('bs-task-id');
-                var modality = eventTarget.data('bs-modality');
-                // update the modal label and contents
-                modal.find(`#${modalId}-label`).text(paramName);
-                var version = getCurrentVersion();
-                var getParameterUrl = getParamUrlFromParamInfo(version, jobType, taskId, modality);
-                loadParameterValue(getParameterUrl, modal);
+                loadParameterValue(getParamUrlFromParamName(eventTarget.data('bs-param-name')));
             }
         }
-        function onResetModal(modalId, isReload = false) {
-            // Resetting the Add New Parameter modal will clear all inputs
-            // Resetting the Edit Existing Parameter modal will reload the parameter value
-            var modal = $(`#${modalId}`);
-            if (modalId === MODAL_ID_ADD) {
-                modal.find(`#${modalId}-job-type-select`).val('');
-                modal.find(`#${modalId}-job-type-input`).val('').hide();
-                modal.find(`#${modalId}-task-id-select`).val('');
-                modal.find(`#${modalId}-task-id-input`).val('').hide();
-                modal.find(`#${modalId}-modality-select`).val('').parent().hide();
-                modal.find(`#${modalId}-content`).val('');
-                toggleParamTextArea(true, modal);
-            } else {
-                if (isReload) {
-                    var paramName = modal.find(`#${modalId}-label`).text();
-                    var url = getParamUrlFromParamName(paramName);
-                    loadParameterValue(url, modal);
+        function onResetModal(reload = false) {
+            const modal = $(`#${MODAL_ID}`);
+            const action = modal.data('bs-action');
+            if (action === "new") {
+                modal.find(`#${MODAL_ID}-dropdowns input`).val('').hide();
+                modal.find(`#${MODAL_ID}-dropdowns select`).val('');
+                modal.find(`#${MODAL_ID}-modality-select`).parent().hide();
+                modal.find(`#${MODAL_ID}-content`).val('');
+                toggleParamTextArea(true);
+            } else if (action === "edit") {
+                if (reload) {
+                    const paramName = modal.find(`#${MODAL_ID}-label`).text();
+                    loadParameterValue(getParamUrlFromParamName(paramName));
                 } else {
-                    modal.find(`#${modalId}-label`).text('');
-                    modal.find(`#${modalId}-content`).val('');
+                    modal.find(`#${MODAL_ID}-label, #${MODAL_ID}-content`).text('').val('');
                 }
             }
         }
-        function onSubmitModal(modalId) {
-            var modal = $(`#${modalId}`);
+        function onSubmitModal() {
+            const modal = $(`#${MODAL_ID}`);
+            const action = modal.data('bs-action');
             let url;
-            if (modalId === MODAL_ID_ADD) {
-                var version = getCurrentVersion();
-                var jobType = getValidatedInputValue('Job Type', modal);
-                var taskId = getValidatedInputValue('Task ID', modal);
-                var modality = (MODALITY_TASKS.includes(taskId)) ? getValidatedInputValue('Modality', modal) : null;
+            if (action === "new") {
+                const version = getCurrentVersion();
+                const jobType = getValidatedInputValue('Job Type', modal);
+                const taskId = getValidatedInputValue('Task ID', modal);
+                const modality = MODALITY_TASKS.includes(taskId) ? getValidatedInputValue('Modality', modal) : null;
                 url = getParamUrlFromParamInfo(version, jobType, taskId, modality);
             } else {
-                var paramName = modal.find(`#${modalId}-label`).text();
+                const paramName = modal.find(`#${MODAL_ID}-label`).text();
                 url = getParamUrlFromParamName(paramName);
             }
-            var paramValue = modal.find(`#${modalId}-content`).val();
-            submitParameterValue(url, paramValue, modal);
+            const paramValue = modal.find(`#${MODAL_ID}-content`).val();
+            submitParameterValue(url, paramValue);
         }
         // Helper methods to get current values
         function getCurrentVersion() {
             return $('#version-button').text().trim();
         }
-        function getUniqueColumnValues(columnSelector) {
-            return Array.from(new Set($('#job-params-table').DataTable().column(columnSelector).data().toArray()));
+        function getUniqueColumnValues(columnTitle) {
+            return Array.from(new Set($('#job-params-table').DataTable().column(`${columnTitle}:title`).data().toArray()));
         }
         function getInputValues(inputField, modal) {
-            const modalId = modal.attr('id');
-            const selector = inputField.toLowerCase().replace(' ', '-');
-            var dropdownVal = modal.find(`#${modalId}-${selector}-select`).val().trim();
-            return {
-                dropdown: dropdownVal,
-                input: (dropdownVal === '__new__') ? modal.find(`#${modalId}-${selector}-input`).val().trim() : dropdownVal
-            };
+            const selector = `#${MODAL_ID}-${inputField.toLowerCase().replace(' ', '-')}`;
+            const dropdown = modal.find(`${selector}-select`).val()?.trim() || '';
+            const input = (dropdown === '__new__') ? (modal.find(`${selector}-input`).val()?.trim() || '') : dropdown;
+            return { dropdown, input };
         }
         function getValidatedInputValue(inputField, modal) {
             // Check for empty string, spaces, slashes, or existing values
-            var inputValues = getInputValues(inputField, modal);
+            const { dropdown, input } = getInputValues(inputField, modal);
             var error = false;
-            if (!inputValues.input) {
+            if (!input) {
                 error = `${inputField} cannot be empty`;
-            } else if (inputValues.input.includes(' ') || inputValues.input.includes('/')) {
+            } else if (input.includes(' ') || input.includes('/')) {
                 error = `${inputField} cannot contain spaces or slashes`;
-            } else if (inputValues.dropdown === '__new__') {
-                var existingValues = getUniqueColumnValues(`${inputField}:title`);
-                if (existingValues.map(val => val.toLowerCase()).includes(inputValues.input.toLowerCase())) {
-                    error = `${inputField} "${inputValues.input}" already exists. Please select it from the dropdown.`;
-                }
+            } else if (
+                dropdown === '__new__' &&
+                getUniqueColumnValues(inputField).some(val => val.toLowerCase() === input.toLowerCase())
+            ) {
+                error = `${inputField} "${input}" already exists. Please select it from the dropdown.`;
             }
             if (error) {
                 alert(error);
                 throw new Error(error);
             }
-            return inputValues.input;
+            return input;
         }
     </script>
 </body>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -62,10 +62,12 @@
                         <th>Modality</th>
                         <th>Parameter Name</th>
                         <th>Last Modified</th>
+                        <th>Actions</th>
                     </tr>
                 </thead>
             </table>
             <!-- modal for displaying param value as json -->
+            <!-- if opened from Edit button, the textarea will be editable and the footer will display the Submit button -->
             <div class="modal fade" id="param-modal" tabindex="-1" aria-labelledby="param-modal-label" aria-hidden="true">
                 <div class="modal-dialog modal-xl">
                     <div class="modal-content">
@@ -74,7 +76,12 @@
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
-                            <pre id="param-modal-content" class="bg-light p-1 border rounded"></pre>
+                            <textarea id="param-modal-content" class="bg-light form-control form-control-sm font-monospace" rows="15" readonly></textarea>
+                        </div>
+                        <div class="modal-footer" hidden>
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                            <button type="button" class="btn btn-secondary" id="reset-param-btn">Reset</button>
+                            <button type="button" class="btn btn-primary" id="submit-param-btn">Submit</button>
                         </div>
                     </div>
                 </div>
@@ -91,29 +98,23 @@
                 var jobType = button.data('bs-job-type');
                 var taskId = button.data('bs-task-id');
                 var modality = button.data('bs-modality');
-                // update the modal label and contents
+                var editEnabled = button.data('bs-edit-enabled');
+                // update the modal label and footer
                 var modal = $(this);
                 modal.find('#param-modal-label').text(paramName);
+                modal.find('.modal-footer').attr('hidden', !editEnabled);
+                modal.find('#param-modal-content').attr('readonly', !editEnabled);
+                // update modal contents
                 var version = $('#version-button').text().trim();
                 var getParameterUrl = `/api/${version}/parameters/job_types/${jobType}/tasks/${taskId}`;
                 if (modality) {
                     getParameterUrl += `/${modality}`;
                 }
-                $.ajax({
-                    url: getParameterUrl,
-                    type: 'GET',
-                    success: function(response) {
-                        jsonStr = JSON.stringify(response.data, null, 3);
-                        modal.find('#param-modal-content').text(jsonStr);
-                    },
-                    error: function(xhr, status, error) {
-                        modal.find('#param-modal-content').text(error);
-                    }
-                });
+                loadParameterValue(getParameterUrl, modal);
             });
             $('#param-modal').on('hidden.bs.modal', function() {
                 $(this).find('#param-modal-label').text('');
-                $(this).find('#param-modal-content').text('');
+                $(this).find('#param-modal-content').val('');
             });
             // Event listener for version dropdown
             $('#version-dropdown .dropdown-item').on('click', function() {
@@ -138,6 +139,7 @@
                     { data: 'modality', searchPanes: {show: false} },
                     { data: 'name', render: renderParameterButton },
                     { data: 'last_modified', render: renderDatetime },
+                    { data: 'name', render: renderActionButtons }
                 ],
                 order: [0, 'asc'],
                 // preselect "default" job_type
@@ -184,11 +186,43 @@
                         data-bs-job-type=${row.job_type} 
                         data-bs-task-id=${row.task_id}
                         data-bs-modality=${row.modality}
+                        data-bs-edit-enabled="false"
                     >${data}
                     </button>`
                 );
             }
             return data;
+        }
+        function renderActionButtons(data, type, row) {
+            if (type == 'display') {
+                return (
+                    `<button type="button" class="btn btn-secondary btn-sm" 
+                        data-bs-toggle="modal" 
+                        data-bs-target="#param-modal" 
+                        data-bs-param-name=${data} 
+                        data-bs-job-type=${row.job_type} 
+                        data-bs-task-id=${row.task_id}
+                        data-bs-modality=${row.modality}
+                        data-bs-edit-enabled="true"
+                    >Edit</button>`
+                );
+            }
+            return data;
+        }
+        // Method to load param values in the modal
+        function loadParameterValue(paramUrl, modal) {
+            $.ajax({
+                url: paramUrl,
+                type: 'GET',
+                success: function (response) {
+                    jsonStr = JSON.stringify(response.data, null, 3);
+                    modal.find('#param-modal-content').val(jsonStr);
+                },
+                error: function (xhr, status, error) {
+                    console.error(`Error fetching ${paramUrl}: ${error}`);
+                    modal.find('#param-modal-content').val(error);
+                }
+            });
         }
     </script>
     </body>

--- a/tests/resources/describe_parameters_response.json
+++ b/tests/resources/describe_parameters_response.json
@@ -35,7 +35,7 @@
             "DataType": "text"
          },
          {
-            "Name": "/param_prefix/v2/job1/tasks/task2/modality1",
+            "Name": "/param_prefix/v2/job1/tasks/modality_transformation_settings/ecephys",
             "ARN": "ARN",
             "Type": "String",
             "LastModifiedDate": "2025-01-23 11:50:04.605000-08:00",

--- a/tests/resources/put_parameter_response.json
+++ b/tests/resources/put_parameter_response.json
@@ -1,0 +1,17 @@
+{
+  "Version": 16,
+  "Tier": "Standard",
+  "ResponseMetadata": {
+    "RequestId": "ffcc56cc-f500-4362-879e-60e9a14c3d36",
+    "HTTPStatusCode": 200,
+    "HTTPHeaders": {
+      "server": "Server",
+      "date": "Mon,30 Jun 2025 21: 16: 24 GMT",
+      "content-type": "application/x-amz-json-1.1",
+      "content-length": "32",
+      "connection": "keep-alive",
+      "x-amzn-requestid": "ffcc56cc-f500-4362-879e-60e9a14c3d36"
+    },
+    "RetryAttempts": 0
+  }
+}


### PR DESCRIPTION
closes #261

This PR includes the following:
- New endpoint to submit a parameter value to AWS. Checks that user is signed in.
- UI modals to edit existing parameter or add a new parameter (only visible for authenticated users).
- Basic validation is done both client- and server-side (JSON serialization, no spaces or slashes in param names).

### Edit existing parameter
- Reset: reload from AWS
- Submit: validate json and submit updated parameter value to AWS
![image](https://github.com/user-attachments/assets/e35664f8-68e0-4b90-8639-8684f113317b)

### Add New Parameter
- Dropdowns: select Job Type (also can provide new value), Task Id (also can provide new value), and Modality (only for modality and CO tasks)
- Reset: clear dropdowns and json textarea
- Submit: validate dropdowns and json and submit updated parameter value to AWS
![image](https://github.com/user-attachments/assets/ec11ab19-ff4e-4672-b331-3f389aacf630)

![image](https://github.com/user-attachments/assets/874d4473-dec2-4d41-92ac-dfe09dbd1bd4)

![image](https://github.com/user-attachments/assets/9a485262-2df3-4ca4-a93b-ec846637fabe)

### Admin page
![image](https://github.com/user-attachments/assets/c2431c2f-a1c9-4351-b51f-52b55046a2fe)
