### PR TITLE
build: upgrades mapper pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
 server = [
     'aind-data-schema>=1.0.0,<2.0',
     'aind-data-transfer-models==0.17.0',
-    'aind-metadata-mapper>=0.27.0',
+    'aind-metadata-mapper==0.27.2',
     'boto3',
     'boto3-stubs[ssm]',
     'fastapi>=0.115.13', 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
 server = [
     'aind-data-schema>=1.0.0,<2.0',
     'aind-data-transfer-models==0.17.0',
-    'aind-metadata-mapper==0.27.2',
+    'aind-metadata-mapper>=0.27.2',
     'boto3',
     'boto3-stubs[ssm]',
     'fastapi>=0.115.13', 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
 server = [
     'aind-data-schema>=1.0.0,<2.0',
     'aind-data-transfer-models==0.17.0',
-    'aind-metadata-mapper==0.23.0',
+    'aind-metadata-mapper>=0.27.0',
     'boto3',
     'boto3-stubs[ssm]',
     'fastapi>=0.115.13', 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
 server = [
     'aind-data-schema>=1.0.0,<2.0',
     'aind-data-transfer-models==0.17.0',
-    'aind-metadata-mapper>=0.27.2',
+    'aind-metadata-mapper>=0.23.0',
     'boto3',
     'boto3-stubs[ssm]',
     'fastapi>=0.115.13', 


### PR DESCRIPTION
closes #269 

Pins mapper to latest version (v0.27.2). Let me know if it's safe to do a lower bound pin instead