### PR TITLE
fix: use httpx.AsyncClient for requests

### DIFF
--- a/src/aind_data_transfer_service/hpc/client.py
+++ b/src/aind_data_transfer_service/hpc/client.py
@@ -3,10 +3,9 @@
 import json
 from typing import List, Optional, Union
 
-import requests
+from httpx import AsyncClient, Response
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings
-from requests.models import Response
 
 from aind_data_transfer_service.hpc.models import HpcJobSubmitSettings
 
@@ -75,37 +74,41 @@ class HpcClient:
             "X-SLURM-USER-TOKEN": self.configs.hpc_token.get_secret_value(),
         }
 
-    def get_node_status(self) -> Response:
+    async def get_node_status(self) -> Response:
         """Get status of nodes"""
-        response = requests.get(
-            url=self._node_status_url, headers=self.__headers
-        )
+        async with AsyncClient() as async_client:
+            response = await async_client.get(
+                url=self._node_status_url, headers=self.__headers
+            )
         return response
 
-    def get_job_status(self, job_id: Union[str, int]) -> Response:
+    async def get_job_status(self, job_id: Union[str, int]) -> Response:
         """Get status of job"""
-        response = requests.get(
-            url=self._job_status_url + "/" + str(job_id),
-            headers=self.__headers,
-        )
+        async with AsyncClient() as async_client:
+            response = await async_client.get(
+                url=self._job_status_url + "/" + str(job_id),
+                headers=self.__headers,
+            )
         return response
 
-    def get_jobs(self) -> Response:
+    async def get_jobs(self) -> Response:
         """Get status of job"""
-        response = requests.get(
-            url=self._jobs_url,
-            headers=self.__headers,
-        )
+        async with AsyncClient() as async_client:
+            response = await async_client.get(
+                url=self._jobs_url,
+                headers=self.__headers,
+            )
         return response
 
-    def submit_job(self, job_def: dict) -> Response:
+    async def submit_job(self, job_def: dict) -> Response:
         """Submit a job defined by job def"""
-        response = requests.post(
-            url=self._job_submit_url, json=job_def, headers=self.__headers
-        )
+        async with AsyncClient() as async_client:
+            response = await async_client.post(
+                url=self._job_submit_url, json=job_def, headers=self.__headers
+            )
         return response
 
-    def submit_hpc_job(
+    async def submit_hpc_job(
         self,
         script: str,
         job: Optional[HpcJobSubmitSettings] = None,
@@ -144,8 +147,8 @@ class HpcClient:
                 ],
                 "script": script,
             }
-
-        response = requests.post(
-            url=self._job_submit_url, json=job_def, headers=self.__headers
-        )
+        async with AsyncClient() as async_client:
+            response = await async_client.post(
+                url=self._job_submit_url, json=job_def, headers=self.__headers
+            )
         return response

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -10,7 +10,6 @@ from pathlib import PurePosixPath
 from typing import Any, List, Optional, Union
 
 import boto3
-import requests
 from aind_data_transfer_models import (
     __version__ as aind_data_transfer_models_version,
 )
@@ -652,7 +651,7 @@ async def submit_basic_jobs(request: Request):
         for hpc_job in hpc_jobs:
             try:
                 job_def = hpc_job.job_definition
-                response = hpc_client.submit_job(job_def)
+                response = await hpc_client.submit_job(job_def)
                 response_json = response.json()
                 responses.append(response_json)
                 # Add pause to stagger job requests to the hpc
@@ -776,7 +775,7 @@ async def submit_hpc_jobs(request: Request):  # noqa: C901
             hpc_job_def = hpc_job[0]
             try:
                 script = hpc_job[1]
-                response = hpc_client.submit_hpc_job(
+                response = await hpc_client.submit_hpc_job(
                     job=hpc_job_def, script=script
                 )
                 response_json = response.json()

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -842,16 +842,18 @@ async def get_tasks_list(request: Request):
             request.query_params
         )
         params_dict = json.loads(params.model_dump_json())
-        response_tasks = requests.get(
-            url=(
-                f"{url}/{params.dag_id}/dagRuns/{params.dag_run_id}/"
-                "taskInstances"
-            ),
+        async with AsyncClient(
             auth=(
                 os.getenv("AIND_AIRFLOW_SERVICE_USER"),
                 os.getenv("AIND_AIRFLOW_SERVICE_PASSWORD"),
-            ),
-        )
+            )
+        ) as async_client:
+            response_tasks = await async_client.get(
+                url=(
+                    f"{url}/{params.dag_id}/dagRuns/{params.dag_run_id}/"
+                    "taskInstances"
+                ),
+            )
         status_code = response_tasks.status_code
         if response_tasks.status_code == 200:
             task_instances = AirflowTaskInstancesResponse.model_validate_json(

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -500,7 +500,6 @@ async def submit_jobs_v2(request: Request):
         full_content = json.loads(
             model.model_dump_json(warnings=False, exclude_none=True)
         )
-        # TODO: Replace with httpx async client
         logger.info(
             f"Valid request detected. Sending list of jobs. "
             f"dag_id: {model.dag_id}"
@@ -512,19 +511,23 @@ async def submit_jobs_v2(request: Request):
                 f"{job_index} of {total_jobs}."
             )
 
-        response = requests.post(
-            url=os.getenv("AIND_AIRFLOW_SERVICE_URL"),
+        async with AsyncClient(
             auth=(
                 os.getenv("AIND_AIRFLOW_SERVICE_USER"),
                 os.getenv("AIND_AIRFLOW_SERVICE_PASSWORD"),
-            ),
-            json={"conf": full_content},
-        )
+            )
+        ) as async_client:
+            response = await async_client.post(
+                url=os.getenv("AIND_AIRFLOW_SERVICE_URL"),
+                json={"conf": full_content},
+            )
+            status_code = response.status_code
+            response_json = response.json()
         return JSONResponse(
-            status_code=response.status_code,
+            status_code=status_code,
             content={
                 "message": "Submitted request to airflow",
-                "data": {"responses": [response.json()], "errors": []},
+                "data": {"responses": [response_json], "errors": []},
             },
         )
     except ValidationError as e:
@@ -558,7 +561,6 @@ async def submit_jobs(request: Request):
         full_content = json.loads(
             model.model_dump_json(warnings=False, exclude_none=True)
         )
-        # TODO: Replace with httpx async client
         logger.info(
             f"Valid request detected. Sending list of jobs. "
             f"Job Type: {model.job_type}"
@@ -570,19 +572,23 @@ async def submit_jobs(request: Request):
                 f"{job_index} of {total_jobs}."
             )
 
-        response = requests.post(
-            url=os.getenv("AIND_AIRFLOW_SERVICE_URL"),
+        async with AsyncClient(
             auth=(
                 os.getenv("AIND_AIRFLOW_SERVICE_USER"),
                 os.getenv("AIND_AIRFLOW_SERVICE_PASSWORD"),
-            ),
-            json={"conf": full_content},
-        )
+            )
+        ) as async_client:
+            response = await async_client.post(
+                url=os.getenv("AIND_AIRFLOW_SERVICE_URL"),
+                json={"conf": full_content},
+            )
+            status_code = response.status_code
+            response_json = response.json()
         return JSONResponse(
-            status_code=response.status_code,
+            status_code=status_code,
             content={
                 "message": "Submitted request to airflow",
-                "data": {"responses": [response.json()], "errors": []},
+                "data": {"responses": [response_json], "errors": []},
             },
         )
 

--- a/tests/test_hpc_client.py
+++ b/tests/test_hpc_client.py
@@ -1,5 +1,6 @@
 """Module to test hpc client classes"""
 
+import asyncio
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -53,12 +54,12 @@ class TestHpcClient(unittest.TestCase):
             "http://hpc_host/job/submit", hpc_client._job_submit_url
         )
 
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_node_status_response(self, mock_get: MagicMock):
         """Tests that the node status request is sent correctly."""
         mock_get.return_value = {"message": "A mocked message"}
         hpc_client = HpcClient(configs=self.hpc_client_configs)
-        response = hpc_client.get_node_status()
+        response = asyncio.run(hpc_client.get_node_status())
         self.assertEqual({"message": "A mocked message"}, response)
         mock_get.assert_called_once_with(
             url="http://hpc_host/nodes",
@@ -69,12 +70,12 @@ class TestHpcClient(unittest.TestCase):
             },
         )
 
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_job_status_response(self, mock_get: MagicMock):
         """Tests that the job status request is sent correctly"""
         mock_get.return_value = {"message": "A mocked message"}
         hpc_client = HpcClient(configs=self.hpc_client_configs)
-        response = hpc_client.get_job_status(job_id="12345")
+        response = asyncio.run(hpc_client.get_job_status(job_id="12345"))
         self.assertEqual({"message": "A mocked message"}, response)
         mock_get.assert_called_once_with(
             url="http://hpc_host/job/12345",
@@ -85,12 +86,12 @@ class TestHpcClient(unittest.TestCase):
             },
         )
 
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_get_jobs_response(self, mock_get: MagicMock):
         """Tests that the job status request is sent correctly"""
         mock_get.return_value = {"message": "A mocked message"}
         hpc_client = HpcClient(configs=self.hpc_client_configs)
-        response = hpc_client.get_jobs()
+        response = asyncio.run(hpc_client.get_jobs())
         self.assertEqual({"message": "A mocked message"}, response)
         mock_get.assert_called_once_with(
             url="http://hpc_host/jobs",
@@ -101,12 +102,14 @@ class TestHpcClient(unittest.TestCase):
             },
         )
 
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     def test_submit_job_response(self, mock_post: MagicMock):
         """Tests that the job submission request is sent correctly"""
         mock_post.return_value = {"message": "A mocked message"}
         hpc_client = HpcClient(configs=self.hpc_client_configs)
-        response = hpc_client.submit_job(job_def={"job": {"some_job"}})
+        response = asyncio.run(
+            hpc_client.submit_job(job_def={"job": {"some_job"}})
+        )
         self.assertEqual({"message": "A mocked message"}, response)
         mock_post.assert_called_once_with(
             url="http://hpc_host/job/submit",
@@ -118,13 +121,16 @@ class TestHpcClient(unittest.TestCase):
             },
         )
 
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     def test_submit_hpc_job_response(self, mock_post: MagicMock):
         """Tests that the job submission request is sent correctly"""
         mock_post.return_value = {"message": "A mocked message"}
         hpc_client = HpcClient(configs=self.hpc_client_configs)
-        response = hpc_client.submit_hpc_job(
-            script="Hello World!", job=HpcJobSubmitSettings(name="test_job")
+        response = asyncio.run(
+            hpc_client.submit_hpc_job(
+                script="Hello World!",
+                job=HpcJobSubmitSettings(name="test_job"),
+            )
         )
         self.assertEqual({"message": "A mocked message"}, response)
         mock_post.assert_called_once_with(
@@ -137,7 +143,7 @@ class TestHpcClient(unittest.TestCase):
             },
         )
 
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     def test_submit_hpc_jobs_response(self, mock_post: MagicMock):
         """Tests that the jobs submission request is sent correctly"""
         mock_post.return_value = {"message": "A mocked message"}
@@ -146,7 +152,9 @@ class TestHpcClient(unittest.TestCase):
             HpcJobSubmitSettings(name="test_job1"),
             HpcJobSubmitSettings(name="test_job2"),
         ]
-        response = hpc_client.submit_hpc_job(script="Hello World!", jobs=jobs)
+        response = asyncio.run(
+            hpc_client.submit_hpc_job(script="Hello World!", jobs=jobs)
+        )
         self.assertEqual({"message": "A mocked message"}, response)
         mock_post.assert_called_once_with(
             url="http://hpc_host/job/submit",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1182,7 +1182,7 @@ class TestServer(unittest.TestCase):
         mock_log_error.assert_called_once()
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_get_task_logs_query_params(
         self,
         mock_get,
@@ -1226,7 +1226,7 @@ class TestServer(unittest.TestCase):
         )
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     @patch("logging.Logger.warning")
     def test_get_task_logs_validation_error(
         self,
@@ -1255,7 +1255,7 @@ class TestServer(unittest.TestCase):
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("logging.Logger.exception")
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_get_task_logs_error(
         self,
         mock_get: MagicMock,
@@ -1686,7 +1686,8 @@ class TestServer(unittest.TestCase):
         )
         self.assertIn("test airflow error", response.text)
 
-    @patch("requests.get")
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    @patch("httpx.AsyncClient.get")
     def test_logs_success(self, mock_get: MagicMock):
         """Tests that task logs page renders as expected."""
         mock_response = Response()
@@ -1708,7 +1709,7 @@ class TestServer(unittest.TestCase):
         self.assertIn("mock log content", response.text)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_logs_failure(self, mock_get: MagicMock):
         """Tests that task logs page renders error message from airflow."""
         mock_response = Response()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1964,7 +1964,7 @@ class TestServer(unittest.TestCase):
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("logging.Logger.warning")
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
@@ -1995,7 +1995,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
@@ -2073,7 +2073,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     @patch("logging.Logger.exception")
     @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
@@ -2169,7 +2169,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(2, mock_get_project_names.call_count)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     @patch("aind_data_transfer_service.server.get_project_names")
     def test_submit_v1_jobs_200_slurm_settings(
         self,
@@ -2227,7 +2227,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(200, submit_job_response.status_code)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     @patch("aind_data_transfer_service.server.get_project_names")
     def test_submit_v1_jobs_200_session_settings_config_file(
         self,
@@ -2295,7 +2295,7 @@ class TestServer(unittest.TestCase):
             self.assertEqual(200, submit_job_response.status_code)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     @patch("aind_data_transfer_service.server.get_project_names")
     def test_submit_v1_jobs_200_trigger_capsule_configs(
         self,
@@ -2352,7 +2352,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(200, submit_job_response.status_code)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.post")
+    @patch("httpx.AsyncClient.post")
     @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 """Tests server module."""
 
+import asyncio
 import json
 import os
 import unittest
@@ -619,7 +620,7 @@ class TestServer(unittest.TestCase):
         self.assertEqual(0, mock_sleep.call_count)
         self.assertEqual(2, mock_log_error.call_count)
 
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_get_project_names(self, mock_get: MagicMock):
         """Tests get_project_names method"""
         mock_response = Response()
@@ -628,7 +629,7 @@ class TestServer(unittest.TestCase):
             {"data": ["project_name_0", "project_name_1"]}
         ).encode("utf-8")
         mock_get.return_value = mock_response
-        project_names = get_project_names()
+        project_names = asyncio.run(get_project_names())
         self.assertEqual(["project_name_0", "project_name_1"], project_names)
 
     @patch("aind_data_transfer_service.server.get_parameter_infos")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -891,7 +891,7 @@ class TestServer(unittest.TestCase):
         )
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_get_tasks_list_query_params(
         self,
         mock_get,
@@ -1131,7 +1131,7 @@ class TestServer(unittest.TestCase):
         )
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     @patch("logging.Logger.warning")
     def test_get_tasks_list_validation_error(
         self,
@@ -1157,7 +1157,7 @@ class TestServer(unittest.TestCase):
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("logging.Logger.exception")
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_get_tasks_list_error(
         self,
         mock_get: MagicMock,
@@ -1641,7 +1641,8 @@ class TestServer(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Jobs Submitted:", response.text)
 
-    @patch("requests.get")
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    @patch("httpx.AsyncClient.get")
     def test_tasks_table_success(self, mock_get: MagicMock):
         """Tests that job tasks table renders as expected."""
         mock_response = Response()
@@ -1660,7 +1661,7 @@ class TestServer(unittest.TestCase):
         self.assertIn("Try Number", response.text)
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
-    @patch("requests.get")
+    @patch("httpx.AsyncClient.get")
     def test_tasks_table_failure(self, mock_get: MagicMock):
         """Tests that job status table renders error message from airflow."""
         mock_response = Response()


### PR DESCRIPTION
closes #105, fixes #270

Replaces all synchronous get/post `requests` with `httpx.AsyncClient`. This will make all of the following non-blocking: hpc client, submit jobs endpoints, project names validation, airflow tasks and logs endpoints.