### PR TITLE
feat: ensure backwards compatibility

### DIFF
--- a/src/aind_data_transfer_service/models/core.py
+++ b/src/aind_data_transfer_service/models/core.py
@@ -205,6 +205,17 @@ class UploadJobConfigsV2(BaseSettings):
             creation_datetime=self.acq_datetime,
         )
 
+    @field_validator("platform", mode="before")
+    def validate_platform(cls, v):
+        """
+        For backwards compatibility, allow a user to input an
+        aind-data-schema-model platform and then convert it.
+        """
+        if type(v).__module__ == "aind_data_schema_models.platforms":
+            return v.model_dump()
+        else:
+            return v
+
     @field_validator("job_type", "project_name", mode="before")
     def validate_with_context(cls, v: str, info: ValidationInfo) -> str:
         """


### PR DESCRIPTION
This PR will:

- If a user has existing scripts that trigger an upload job, then no changes will be needed on their end
- If a user has existing scripts that trigger an upload job and they upgrade aind-data-transfer-service, then no changes will be required, but a warning message might show up about types
- If a user has existing scripts that trigger an upload job and they upgrade aind-data-transfer-service and they upgrade aind-data-schema, then an error is likely to be raised since the aind_data_schema platform model no longer exists.

The current implementation in this PR will still honor the "platform" field and use it to the s3_prefix if provided. As an alternative, I can make the "platform" field an "Any" object and completely ignore it. This may break downstream processes though.