### PR TITLE
feat: adds retry_count field

### DIFF
--- a/src/aind_data_transfer_service/models/core.py
+++ b/src/aind_data_transfer_service/models/core.py
@@ -93,6 +93,13 @@ class Task(BaseModel):
             """
         ),
     )
+    retry_count: int = Field(
+        default=0,
+        description=(
+            "Experimental parameter to retry failed compression jobs. Please "
+            "ask a member of Scientific Computing for more info before using."
+        ),
+    )
 
     @field_validator(
         "image_resources",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,6 +39,7 @@ class TestTask(unittest.TestCase):
         self.assertDictEqual(
             {
                 "skip_task": False,
+                "retry_count": 0,
                 "image": "some_image",
                 "image_version": "1.0.0",
                 "image_resources": {"key": "value"},
@@ -53,6 +54,7 @@ class TestTask(unittest.TestCase):
         # skippable task
         expected_configs = {
             "skip_task": True,
+            "retry_count": 0,
             "image": None,
             "image_version": None,
             "image_resources": None,


### PR DESCRIPTION
- Adds a field that will allow users to declare whether they want to retry a failed compression job.