### PR TITLE
fix: add validator for modality tasks

### DIFF
--- a/src/aind_data_transfer_service/models/core.py
+++ b/src/aind_data_transfer_service/models/core.py
@@ -240,6 +240,31 @@ class UploadJobConfigsV2(BaseSettings):
         else:
             return v
 
+    @field_validator("tasks", mode="after")
+    def validate_tasks(
+        cls, v: Dict[str, Union[Task, Dict[str, Task]]]
+    ) -> Dict[str, Union[Task, Dict[str, Task]]]:
+        """Validate that modality-specific tasks are keyed by valid
+        modality abbreviations."""
+        modality_tasks = [
+            "modality_transformation_settings",
+            "codeocean_pipeline_settings",
+        ]
+        for task_id, task_value in v.items():
+            if task_id in modality_tasks:
+                if not isinstance(task_value, dict):
+                    raise ValueError(
+                        f"{task_id} must be a dictionary of modality "
+                        f"abbreviations to Task objects."
+                    )
+                for modality_key in task_value.keys():
+                    if modality_key not in Modality.abbreviation_map:
+                        raise ValueError(
+                            f'Key {modality_key} in tasks["{task_id}"] is not '
+                            f"a valid modality abbreviation."
+                        )
+        return v
+
 
 class SubmitJobRequestV2(BaseSettings):
     """Main request that will be sent to the backend. Bundles jobs into a list

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -260,6 +260,38 @@ class TestUploadJobConfigsV2(unittest.TestCase):
             len(job_configs.tasks["modality_transformation_settings"].items()),
         )
 
+    def test_check_modality_tasks(self):
+        """Tests that modality tasks must be provided as dict of tasks"""
+        configs = self.base_configs.copy()
+        configs["tasks"] = {
+            "modality_transformation_settings": Task(
+                job_settings={"input_source": "dir/data_set_1"}
+            ),
+        }
+        with self.assertRaises(ValidationError) as e:
+            UploadJobConfigsV2(**configs)
+        expected_message = (
+            "modality_transformation_settings must be a dictionary of "
+            "modality abbreviations to Task objects."
+        )
+        self.assertIn(expected_message, str(e.exception))
+
+    def test_check_modality_tasks_keys(self):
+        """Tests that modality tasks have valid abbreviations as keys"""
+        configs = self.base_configs.copy()
+        configs["tasks"] = {
+            "codeocean_pipeline_settings": {
+                "foo": Task(job_settings={"input_source": "dir/data_set_1"}),
+            },
+        }
+        with self.assertRaises(ValidationError) as e:
+            UploadJobConfigsV2(**configs)
+        expected_message = (
+            'Key foo in tasks["codeocean_pipeline_settings"] is not a valid '
+            "modality abbreviation."
+        )
+        self.assertIn(expected_message, str(e.exception))
+
 
 class TestSubmitJobRequestV2(unittest.TestCase):
     """Tests SubmitJobRequestV2 class"""
@@ -277,11 +309,11 @@ class TestSubmitJobRequestV2(unittest.TestCase):
             subject_id="123456",
             acq_datetime=datetime(2020, 10, 13, 13, 10, 10),
             tasks={
-                "modality_transformation_settings": Task(
-                    job_settings={
-                        "input_source": "dir/data_set_1",
-                    },
-                )
+                "modality_transformation_settings": {
+                    "behavior-videos": Task(
+                        job_settings={"input_source": "dir/data_set_1"},
+                    ),
+                }
             },
         )
         cls.example_upload_config = example_upload_config
@@ -423,9 +455,14 @@ class TestSubmitJobRequestV2(unittest.TestCase):
         upload_jobs = list()
         for i in range(10):
             tasks = {
-                "modality_transformation_settings": Task(
-                    job_settings={"input_source": "dir/data", "chunk": str(i)}
-                )
+                "modality_transformation_settings": {
+                    "behavior-videos": Task(
+                        job_settings={
+                            "input_source": "dir/data",
+                            "chunk": str(i),
+                        }
+                    )
+                }
             }
             upload_jobs.append(UploadJobConfigsV2(**job_configs, tasks=tasks))
         submit_job_request = SubmitJobRequestV2(upload_jobs=upload_jobs)


### PR DESCRIPTION
closes #305 

Buggy behavior was due to incorrect modality keys being deserialized as empty Tasks. This PR adds a validator to check that `modality_transformation_settings` and `codeocean_pipeline_settings` are provided as a dictionary of valid modality abbrevations to Tasks.

Example:
```py
# Accepted
tasks={
    "modality_transformation_settings": {
        "ecephys": Task(...),
        Modality.BEHAVIOR_VIDEOS.abbreviation: Task(...),
    }
}

# Invalid modality abbreviations
tasks={
    "modality_transformation_settings": {
        "foo": Task(...),
        Modality.BEHAVIOR_VIDEOS: Task(...),
    }
}
# Invalid/ missing modality key
tasks={
    "modality_transformation_settings": Task(...),
}

```