### PR TITLE
feat: confirmation popup for job cancellation

### DIFF
--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -354,10 +354,16 @@
             document.getElementById('cancel-modal-job-id').textContent = cancelModal.dataset.jobId;
         }
         function resetCancelJobModal() {
+            // clear modal content
             document.getElementById('cancel-modal-job-name').textContent = '';
             document.getElementById('cancel-modal-job-id').textContent = '';
             document.getElementById('cancel-confirm-input').value = '';
             document.getElementById('cancel-confirm-button').disabled = true;
+            // clear stored data in modal dataset
+            const cancelModal = document.getElementById('cancel-modal-full');
+            cancelModal.dataset.dagId = '';
+            cancelModal.dataset.jobId = '';
+            cancelModal.dataset.jobName = '';
         }
         function cancelUploadJob() {
             // Get job data from modal dataset


### PR DESCRIPTION
related to #328

This PR adds a confirmation popup as part of the cancel jobs UI feature:
- Displays warning message to user
- Includes confirmation text input to prompt user to type "YES"
- If user types "YES", confirm button becomes clickable.
- When the modal is closed, all inputs are reset.
- Also fixes a small bug with mis-aligned column indexes.

<img width="793" height="571" alt="image" src="https://github.com/user-attachments/assets/31878713-bd62-4581-9f52-124fed437780" />
