### PR TITLE
feat: new cancel job button on job_status page

### DIFF
--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -425,7 +425,7 @@
                     spinner.hidden = true;
                     const errMsg = xhr.responseJSON?.data?.error || error;
                     const errorDiv = document.getElementById('error-message');
-                    errorDiv.textContent = `Error sending cancellation requestt: ${errMsg}`;
+                    errorDiv.textContent = `Error sending cancellation request: ${errMsg}`;
                     errorDiv.hidden = false;
                     confirmButton.prop('disabled', false);
                 }


### PR DESCRIPTION
Closes #328 

This PR introduces a new “Cancel Job” action to the Job Status page, allowing users to cancel running or queued upload jobs directly from the UI.

**Key additions**

New cancel button column in the full jobs table
- Displays a red, rounded “X” button for each row.
- Button is enabled only for jobs in running or queued state.
- Opens a dedicated cancel confirmation modal when clicked.

New Cancel Job modal (cancel-modal-full)
- Shows job details (Asset Name + Job ID).
- Warns the user about partial cloud uploads.
- Requires the user to type “YES” to enable the Confirm button.
- Pressing Enter also triggers cancellation when the input matches “YES”.

Feedback UI added below the Confirm button
- Spinner shown while waiting for the backend.
- Success message ("Cancel Request Sent") on success.
- Error message with backend-provided details on failure.

DataTable integration
- Added a new first column for the cancel button.
- The jobs table refreshes automatically after a successful cancel request.

Modal lifecycle handling
- On show, modal fields populate using dataset values (dagId, jobId, jobName).
- On hide, the modal fully resets state, including input, messages, spinner visibility, and stored metadata.

**Screenshots demonstrating the process:**
![Full jobs table showing cancel options - 1](https://github.com/user-attachments/assets/2e2f92b4-e68a-4eb8-b63e-26e9ec3738a6)
![Initial cancel modal opening - 2](https://github.com/user-attachments/assets/f34c7253-c736-4f43-b7ef-0734a5398cb7)
![Sending cancel request - 3](https://github.com/user-attachments/assets/4b258e96-291b-4922-ad23-a0a7a1400cc3)
![Successful cancel request - 4](https://github.com/user-attachments/assets/1b47c5b4-b53e-44e9-bfaa-3946b61ab01c)
