### PR TITLE
fix: updates task validator to handle skip_task

### DIFF
--- a/src/aind_data_transfer_service/models/core.py
+++ b/src/aind_data_transfer_service/models/core.py
@@ -252,6 +252,8 @@ class UploadJobConfigsV2(BaseSettings):
         ]
         for task_id, task_value in v.items():
             if task_id in modality_tasks:
+                if isinstance(task_value, Task) and task_value.skip_task:
+                    continue
                 if not isinstance(task_value, dict):
                     raise ValueError(
                         f"{task_id} must be a dictionary of modality "

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 
 import json
 import unittest
+from copy import deepcopy
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -71,7 +72,7 @@ class TestTask(unittest.TestCase):
             "job_settings",
         ]:
             expected_error = f"Value error, {field} must be json serializable!"
-            invalid_configs = self.custom_task_configs.copy()
+            invalid_configs = deepcopy(self.custom_task_configs)
             invalid_configs[field] = {"param1": list}
             with self.assertRaises(ValidationError) as e:
                 Task(**invalid_configs)
@@ -233,7 +234,7 @@ class TestUploadJobConfigsV2(unittest.TestCase):
 
     def test_check_tasks(self):
         """Tests that tasks can be set correctly"""
-        configs = self.base_configs.copy()
+        configs = deepcopy(self.base_configs)
         configs["tasks"] = {
             "modality_transformation_settings": {
                 "behavior-videos": Task(
@@ -262,7 +263,7 @@ class TestUploadJobConfigsV2(unittest.TestCase):
 
     def test_check_modality_tasks(self):
         """Tests that modality tasks must be provided as dict of tasks"""
-        configs = self.base_configs.copy()
+        configs = deepcopy(self.base_configs)
         configs["tasks"] = {
             "modality_transformation_settings": Task(
                 job_settings={"input_source": "dir/data_set_1"}
@@ -276,9 +277,22 @@ class TestUploadJobConfigsV2(unittest.TestCase):
         )
         self.assertIn(expected_message, str(e.exception))
 
+    def test_check_modality_tasks_with_skip_task(self):
+        """Tests that validation check is valid when skip_task is True"""
+        configs = deepcopy(self.base_configs)
+        configs["tasks"] = {
+            "modality_transformation_settings": Task(
+                skip_task=True,
+            ),
+        }
+        job = UploadJobConfigsV2(**configs)
+        self.assertTrue(
+            job.tasks["modality_transformation_settings"].skip_task
+        )
+
     def test_check_modality_tasks_keys(self):
         """Tests that modality tasks have valid abbreviations as keys"""
-        configs = self.base_configs.copy()
+        configs = deepcopy(self.base_configs)
         configs["tasks"] = {
             "codeocean_pipeline_settings": {
                 "foo": Task(job_settings={"input_source": "dir/data_set_1"}),


### PR DESCRIPTION
- Allows a user to set modality_transformation_settings and codeocean_pipeline_settings to `Task(skip_task=True)`