### PR TITLE
fix: remove modality validator for job param name

### DIFF
--- a/src/aind_data_transfer_service/models/internal.py
+++ b/src/aind_data_transfer_service/models/internal.py
@@ -239,16 +239,6 @@ class JobParamInfo(BaseModel):
     modality: Optional[str]
     version: Optional[str] = Field(..., pattern=r"^(v1|v2)?$")
 
-    @field_validator("modality", mode="after")
-    def validate_modality(cls, v):
-        """Check that modality is one of aind-data-schema modalities"""
-        if v is not None and v not in JobParamInfo._MODALITIES_LIST:
-            raise ValueError(
-                "Invalid modality: modality must be one of "
-                f"{JobParamInfo._MODALITIES_LIST}"
-            )
-        return v
-
     @classmethod
     def from_aws_describe_parameter(
         cls,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1073,8 +1073,6 @@ class TestServer(unittest.TestCase):
             "/api/v3/parameters/job_types/ecephys/tasks/task1",
             "/api/v2/parameters/job_types/new job/tasks/task1",
             "/api/v2/parameters/job_types/new_job/tasks/new task",
-            "/api/v2/parameters/job_types/new_job/tasks"
-            "/codeocean_pipeline_settings/foo",
         ]
         for url in request_urls:
             with TestClient(app) as client:


### PR DESCRIPTION
fixes #356 

Removes modality validator for Job Params in the data transfer service backend so that it is backwards compatible with aind-data-schema-models changes. The front end still "validates" new parameters, i.e. users must select modalities from a dropdown.