### PR TITLE
feat: adds event type logs to transfer-service

### DIFF
--- a/src/aind_data_transfer_service/log_handler.py
+++ b/src/aind_data_transfer_service/log_handler.py
@@ -10,6 +10,7 @@ class EventType(str, Enum):
 
     STAGE_START = "stage_start"
     STAGE_COMPLETE = "stage_complete"
+    STAGE_FAILURE = "stage_failure"
 
 
 def log_stage_event(

--- a/src/aind_data_transfer_service/log_handler.py
+++ b/src/aind_data_transfer_service/log_handler.py
@@ -11,12 +11,17 @@ class EventType(str, Enum):
     STAGE_START = "stage_start"
     STAGE_COMPLETE = "stage_complete"
 
-def log_stage_event(message: str, event_type: str, **extra_fields: Any) -> None:
+
+def log_stage_event(
+        message: str,
+        event_type: EventType,
+        **extra_fields: Any
+) -> None:
     """Emit a structured log record for stage lifecycle events."""
 
     logging.info(
         message,
-        extra={"event_type": event_type, **extra_fields},
+        extra={"event_type": event_type.value, **extra_fields},
     )
 
 

--- a/src/aind_data_transfer_service/log_handler.py
+++ b/src/aind_data_transfer_service/log_handler.py
@@ -2,6 +2,22 @@
 
 import logging
 from typing import Any
+from enum import Enum
+
+
+class EventType(str, Enum):
+    """Enum for event types in structured logging"""
+
+    STAGE_START = "stage_start"
+    STAGE_COMPLETE = "stage_complete"
+
+def log_stage_event(message: str, event_type: str, **extra_fields: Any) -> None:
+    """Emit a structured log record for stage lifecycle events."""
+
+    logging.info(
+        message,
+        extra={"event_type": event_type, **extra_fields},
+    )
 
 
 def log_submit_job_request(content: Any) -> None:
@@ -20,10 +36,9 @@ def log_submit_job_request(content: Any) -> None:
         for row in content:
             subject_id = row.get("subject_id")
             acquisition_name = row.get("s3_prefix")
-            logging.info(
+            log_stage_event(
                 "Handling request",
-                extra={
-                    "subject_id": subject_id,
-                    "acquisition_name": acquisition_name,
-                },
+                event_type=EventType.STAGE_START,
+                subject_id=subject_id,
+                acquisition_name=acquisition_name,
             )

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -31,7 +31,11 @@ from aind_data_transfer_service.configs.csv_handler import map_csv_row_to_job
 from aind_data_transfer_service.configs.job_upload_template import (
     JobUploadTemplate,
 )
-from aind_data_transfer_service.log_handler import log_submit_job_request
+from aind_data_transfer_service.log_handler import (
+    EventType,
+    log_stage_event,
+    log_submit_job_request,
+)
 from aind_data_transfer_service.models.core import (
     SubmitJobRequestV2,
     validation_context,
@@ -393,6 +397,13 @@ async def submit_jobs_v2(request: Request):
             )
             status_code = response.status_code
             response_json = response.json()
+        log_stage_event(
+            "Completed submit jobs v2 request",
+            event_type=EventType.STAGE_COMPLETE,
+            dag_id=model.dag_id,
+            total_jobs=total_jobs,
+            status_code=status_code,
+        )
         return JSONResponse(
             status_code=status_code,
             content={

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -397,7 +397,7 @@ async def submit_jobs_v2(request: Request):
             )
             status_code = response.status_code
             response_json = response.json()
-        if status_code == 500:
+        if status_code > 300:
             log_stage_event(
                 "Failed submit jobs v2 request",
                 event_type=EventType.STAGE_FAILURE,

--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -397,13 +397,22 @@ async def submit_jobs_v2(request: Request):
             )
             status_code = response.status_code
             response_json = response.json()
-        log_stage_event(
-            "Completed submit jobs v2 request",
-            event_type=EventType.STAGE_COMPLETE,
-            dag_id=model.dag_id,
-            total_jobs=total_jobs,
-            status_code=status_code,
-        )
+        if status_code == 500:
+            log_stage_event(
+                "Failed submit jobs v2 request",
+                event_type=EventType.STAGE_FAILURE,
+                dag_id=model.dag_id,
+                total_jobs=total_jobs,
+                status_code=status_code,
+            )
+        else:
+            log_stage_event(
+                "Completed submit jobs v2 request",
+                event_type=EventType.STAGE_COMPLETE,
+                dag_id=model.dag_id,
+                total_jobs=total_jobs,
+                status_code=status_code,
+            )
         return JSONResponse(
             status_code=status_code,
             content={
@@ -422,6 +431,12 @@ async def submit_jobs_v2(request: Request):
         )
     except Exception as e:
         logging.exception(e, exc_info=True)
+        log_stage_event(
+            "Failed submit jobs v2 request",
+            event_type=EventType.STAGE_FAILURE,
+            content=content,
+            error=str(e.args),
+        )
         return JSONResponse(
             status_code=500,
             content={

--- a/tests/test_log_handler.py
+++ b/tests/test_log_handler.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import aind_data_transfer_service
 from aind_data_transfer_service import CustomJsonFormatter
-from aind_data_transfer_service.log_handler import log_submit_job_request
+from aind_data_transfer_service.log_handler import (
+    EventType,
+    log_stage_event,
+    log_submit_job_request,
+)
 
 
 class TestLogHandler(unittest.TestCase):
@@ -20,7 +24,31 @@ class TestLogHandler(unittest.TestCase):
         log_submit_job_request(content=content)
         mock_log.assert_called_once_with(
             "Handling request",
-            extra={"subject_id": "123456", "acquisition_name": "abc-123"},
+            extra={
+                "event_type": EventType.STAGE_START,
+                "subject_id": "123456",
+                "acquisition_name": "abc-123",
+            },
+        )
+
+    @patch("logging.info")
+    def test_log_stage_event(self, mock_log: MagicMock):
+        """Tests log_stage_event emits structured extra fields."""
+
+        log_stage_event(
+            "Completed submit jobs v2 request",
+            event_type=EventType.STAGE_COMPLETE,
+            dag_id="run_list_of_jobs",
+            total_jobs=2,
+        )
+
+        mock_log.assert_called_once_with(
+            "Completed submit jobs v2 request",
+            extra={
+                "event_type": EventType.STAGE_COMPLETE,
+                "dag_id": "run_list_of_jobs",
+                "total_jobs": 2,
+            },
         )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1629,6 +1629,7 @@ class TestServer(unittest.TestCase):
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("httpx.AsyncClient.post")
+    @patch("aind_data_transfer_service.server.log_stage_event")
     @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
@@ -1637,9 +1638,60 @@ class TestServer(unittest.TestCase):
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
         mock_get_airflow_jobs: MagicMock,
+        mock_log_stage_event: MagicMock,
         mock_post: MagicMock,
     ):
-        """Tests submit jobs 500 response."""
+        """Tests submit jobs failure."""
+        mock_get_project_names.return_value = ["Ephys Platform"]
+        mock_get_job_types.return_value = ["ecephys"]
+        mock_get_airflow_jobs.return_value = (0, list())
+        mock_response = Response()
+        mock_response.status_code = 500
+        mock_response._content = json.dumps({"message": "sent"}).encode(
+            "utf-8"
+        )
+        mock_post.return_value = mock_response
+        job_request_v2 = SubmitJobRequestV2(
+            upload_jobs=[self.example_configs_v2]
+        )
+        request_json_v2 = job_request_v2.model_dump(mode="json")
+        with self.assertLogs(level="INFO") as captured:
+            with TestClient(app) as client:
+                submit_job_response = client.post(
+                    url="/api/v2/submit_jobs", json=request_json_v2
+                )
+        self.assertEqual(500, submit_job_response.status_code)
+        mock_get_job_types.assert_called_once_with("v2")
+        expected_airflow_params = AirflowDagRunsRequestParameters(
+            dag_ids=["transform_and_upload_v2", "run_list_of_jobs"],
+            states=["running", "queued"],
+        )
+        mock_get_airflow_jobs.assert_called_once_with(
+            params=expected_airflow_params, get_confs=True
+        )
+        self.assertEqual(1, mock_get_project_names.call_count)
+        self.assertEqual(4, len(captured.output))
+        mock_log_stage_event.assert_called_once_with(
+            "Failed submit jobs v2 request",
+            event_type="stage_failure",
+            dag_id="transform_and_upload_v2",
+            total_jobs=1,
+            status_code=500,
+        )
+
+    @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
+    @patch("httpx.AsyncClient.post")
+    @patch("aind_data_transfer_service.server.get_airflow_jobs")
+    @patch("aind_data_transfer_service.server.get_project_names")
+    @patch("aind_data_transfer_service.server.get_job_types")
+    def test_submit_v1_v2_jobs_exception_500(
+        self,
+        mock_get_job_types: MagicMock,
+        mock_get_project_names: MagicMock,
+        mock_get_airflow_jobs: MagicMock,
+        mock_post: MagicMock,
+    ):
+        """Tests submit jobs exception response."""
         mock_get_job_types.return_value = ["ecephys"]
         mock_get_project_names.return_value = ["Ephys Platform"]
         mock_get_airflow_jobs.return_value = (0, list())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,7 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path, PurePosixPath
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aind_data_schema_models.modalities import Modality
 from authlib.integrations.starlette_client import OAuthError
@@ -1622,7 +1622,7 @@ class TestServer(unittest.TestCase):
         mock_log_stage_event.assert_called_once_with(
             "Completed submit jobs v2 request",
             event_type="stage_complete",
-            dag_id=ANY,
+            dag_id="transform_and_upload_v2",
             total_jobs=1,
             status_code=200,
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,7 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path, PurePosixPath
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from aind_data_schema_models.modalities import Modality
 from authlib.integrations.starlette_client import OAuthError
@@ -1577,6 +1577,7 @@ class TestServer(unittest.TestCase):
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("httpx.AsyncClient.post")
+    @patch("aind_data_transfer_service.server.log_stage_event")
     @patch("aind_data_transfer_service.server.get_airflow_jobs")
     @patch("aind_data_transfer_service.server.get_project_names")
     @patch("aind_data_transfer_service.server.get_job_types")
@@ -1585,6 +1586,7 @@ class TestServer(unittest.TestCase):
         mock_get_job_types: MagicMock,
         mock_get_project_names: MagicMock,
         mock_get_airflow_jobs: MagicMock,
+        mock_log_stage_event: MagicMock,
         mock_post: MagicMock,
     ):
         """Tests submit jobs success."""
@@ -1617,6 +1619,13 @@ class TestServer(unittest.TestCase):
         )
         self.assertEqual(1, mock_get_project_names.call_count)
         self.assertEqual(4, len(captured.output))
+        mock_log_stage_event.assert_called_once_with(
+            "Completed submit jobs v2 request",
+            event_type="stage_complete",
+            dag_id=ANY,
+            total_jobs=1,
+            status_code=200,
+        )
 
     @patch.dict(os.environ, EXAMPLE_ENV_VAR1, clear=True)
     @patch("httpx.AsyncClient.post")
@@ -1712,7 +1721,7 @@ class TestServer(unittest.TestCase):
                     url="/api/v2/submit_jobs", json=post_request_content_v2
                 )
         self.assertEqual(200, submit_job_response.status_code)
-        self.assertEqual(4, len(captured.output))
+        self.assertEqual(5, len(captured.output))
         mock_get_job_types.assert_called_once_with("v2")
         mock_get_airflow_jobs.assert_called_once()
         self.assertEqual(1, mock_get_project_names.call_count)


### PR DESCRIPTION
closes https://github.com/AllenNeuralDynamics/aind-scientific-computing/issues/665

This PR:
- adds logging helper to ensure logs are all same format
- adds `event_type` to logs for stage. `event type = stage_complete | stage_start | stage_failure`