### PR TITLE
fix: email requirement in UI

### DIFF
--- a/src/aind_data_transfer_service/templates/index.html
+++ b/src/aind_data_transfer_service/templates/index.html
@@ -55,9 +55,9 @@
     <h4 class="my-3 fw-bold">Submit Jobs</h4>
         <div>
         <fieldset>
-            <legend>Mail Notifications (optional)</legend><br>
+            <legend>Mail Notifications (required) </legend><br>
             <div>
-                <label for="email" title="Optionally provide an allen institute email address to receive upload job status notifications">Allen Institute email:</label>
+                <label for="email" title="Provide an allen institute email address to receive upload job status notifications">Allen Institute email:</label>
                 <input type="email" id="email" pattern=".+@alleninstitute\.org" size="30" placeholder="@alleninstitute.org" /><br><br>
             </div>
             <div>


### PR DESCRIPTION
We should probably update the UI to make it clear that emails are now required. 

Related to #408 