### PR TITLE
ci: adds a notice banner

### DIFF
--- a/src/aind_data_transfer_service/templates/admin.html
+++ b/src/aind_data_transfer_service/templates/admin.html
@@ -16,6 +16,19 @@
   </style>
 </head>
 <body>
+    <!-- Maintenance Banner - Delete this section after maintenance -->
+    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        <div class="d-flex align-items-center">
+            <i class="bi bi-exclamation-triangle-fill me-2" style="font-size: 1.2em;"></i>
+            <div>
+                <strong>Scheduled Maintenance Notice:</strong> 
+                The data transfer service will be undergoing maintenance on 
+                <strong>Wednesday, June 17th from 9:00 AM - 11:00 AM Pacific Time</strong>. 
+                Please refrain from submitting upload jobs during this time period.
+            </div>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
   {% include 'nav_bar.html' %}
   <div>
     <h3>Admin</h3>

--- a/src/aind_data_transfer_service/templates/index.html
+++ b/src/aind_data_transfer_service/templates/index.html
@@ -48,6 +48,19 @@
     </style>
 </head>
 <body>
+    <!-- Maintenance Banner - Delete this section after maintenance -->
+    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        <div class="d-flex align-items-center">
+            <i class="bi bi-exclamation-triangle-fill me-2" style="font-size: 1.2em;"></i>
+            <div>
+                <strong>Scheduled Maintenance Notice:</strong> 
+                The data transfer service will be undergoing maintenance on 
+                <strong>Wednesday, June 17th from 9:00 AM - 11:00 AM Pacific Time</strong>. 
+                Please refrain from submitting upload jobs during this time period.
+            </div>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
     {% include 'nav_bar.html' %}
     <div>
         <p1>For instructions on how to submit jobs click on the Help tab</p1>

--- a/src/aind_data_transfer_service/templates/job_params.html
+++ b/src/aind_data_transfer_service/templates/job_params.html
@@ -28,6 +28,19 @@
     </style>
 </head>
 <body>
+    <!-- Maintenance Banner - Delete this section after maintenance -->
+    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        <div class="d-flex align-items-center">
+            <i class="bi bi-exclamation-triangle-fill me-2" style="font-size: 1.2em;"></i>
+            <div>
+                <strong>Scheduled Maintenance Notice:</strong> 
+                The data transfer service will be undergoing maintenance on 
+                <strong>Wednesday, June 17th from 9:00 AM - 11:00 AM Pacific Time</strong>. 
+                Please refrain from submitting upload jobs during this time period.
+            </div>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
     {% include 'nav_bar.html' %}
     <div class="content">
         <h4 class="mb-2">

--- a/src/aind_data_transfer_service/templates/job_status.html
+++ b/src/aind_data_transfer_service/templates/job_status.html
@@ -26,6 +26,19 @@
     </style>
 </head>
 <body>
+    <!-- Maintenance Banner - Delete this section after maintenance -->
+    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        <div class="d-flex align-items-center">
+            <i class="bi bi-exclamation-triangle-fill me-2" style="font-size: 1.2em;"></i>
+            <div>
+                <strong>Scheduled Maintenance Notice:</strong> 
+                The data transfer service will be undergoing maintenance on 
+                <strong>Wednesday, June 17th from 9:00 AM - 11:00 AM Pacific Time</strong>. 
+                Please refrain from submitting upload jobs during this time period.
+            </div>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
     {% include 'nav_bar.html' %}
     <div class="content">
         <!-- display total entries -->


### PR DESCRIPTION
This PR a scheduled maintenance banner to all major user-facing pages of the data transfer service web app. 

* Added a dismissible maintenance alert banner to the top of the following templates: `admin.html`, `index.html`, `job_params.html`, and `job_status.html`, notifying users of scheduled maintenance on Wednesday, June 17th from 9:00 AM to 11:00 AM Pacific Time.