### PR TITLE
fix: serializes the airflow param in model

### DIFF
--- a/src/aind_data_transfer_service/server.py
+++ b/src/aind_data_transfer_service/server.py
@@ -278,15 +278,16 @@ async def get_airflow_jobs(
 
     airflow_url = os.getenv("AIND_AIRFLOW_SERVICE_JOBS_URL", "").strip("/")
     airflow_url = f"{airflow_url}/~/dagRuns/list"
-    params_dict = {
-        "dag_ids": dag_ids,
-        "page_limit": page_limit,
-        "page_offset": page_offset,
-        "states": states,
-        "execution_date_gte": execution_date_gte,
-        "execution_date_lte": execution_date_lte,
-        "order_by": order_by,
-    }
+    params = AirflowDagRunsRequestParameters(
+        dag_ids=dag_ids,
+        page_limit=page_limit,
+        page_offset=page_offset,
+        states=states,
+        execution_date_gte=execution_date_gte,
+        execution_date_lte=execution_date_lte,
+        order_by=order_by,
+    )
+    params_dict = json.loads(params.model_dump_json(exclude_none=True))
     # Send request to Airflow to ListDagRuns
     async with AsyncClient(
         auth=(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -186,6 +186,9 @@ class TestServer:
             mock_post.call_args_list[0][0][0]
             == "airflow_jobs_url/~/dagRuns/list"
         )
+        posted_body = mock_post.call_args_list[0].kwargs["json"]
+        assert "execution_date_lte" not in posted_body
+        assert all(v is not None for v in posted_body.values())
         assert 1 == len(caplog.messages)
 
     @patch("httpx.AsyncClient.post")


### PR DESCRIPTION
There were two things in our previous release that was leading to the break in the `submit_jobs` endpoint: 
- The Time out for airflow list dags request was removed. We've added back in another branch 
- The params need to exclude None values. Using the model from Airflow like the other endpoints are instead of passing a dict to validate the params dict and exclude_none